### PR TITLE
[fix]MergePhedex script fails with "" gid ('""')

### DIFF
--- a/bin/cron4dbs_condor
+++ b/bin/cron4dbs_condor
@@ -9,7 +9,6 @@ addr=vkuznet@gmail.com
 # for Spark 2.X
 export PATH=$PATH:/usr/hdp/hadoop/bin
 export HADOOP_CONF_DIR=/etc/hadoop/conf
-export JAVA_HOME=/
 
 # find out which date we should use to run the script
 year=`date +'%Y'`

--- a/bin/cron4dbs_events
+++ b/bin/cron4dbs_events
@@ -19,9 +19,6 @@ odir=$1
 #fi
 #klist -k "$keytab" 2>&1 1>& /dev/null
 
-# environemnt for JAVA
-export JAVA_HOME=/
-
 # setup to run the script
 me=$(dirname "$0")
 wdir=`echo $me | sed -e "s,/bin,,g"`

--- a/bin/cron4phedex
+++ b/bin/cron4phedex
@@ -9,7 +9,6 @@ addr=vkuznet@gmail.com
 # for Spark 2.X
 export PATH=$PATH:/usr/hdp/hadoop/bin
 export HADOOP_CONF_DIR=/etc/hadoop/conf
-export JAVA_HOME=/
 conf=$1
 keytab=`cat $conf | python -c "import sys, json; print json.load(sys.stdin)['keytab']"`
 principal=`klist -k "$keytab" | tail -1 | awk '{print $2}'`


### PR DESCRIPTION
This fix allows the merge phedex script to work with unexpected values of gid (in this case `""` in a file of April, but it depends on the format). It will log the unexpected values (so it can reveal format changes on the source data). 
I've reverted the latest commit as setting the JAVA_HOME to the root path may cause some problems in the future (with the current configuration is not being used, but that can change). 