### PR TITLE
[hadoop] Start a login shell to use the profile.d conf

### DIFF
--- a/bin/backfill_dbs_condor.sh
+++ b/bin/backfill_dbs_condor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -l
 # This script check if a file for each date exists and, if not, it creates it. 
 # This script requieres a hadoop environment. 
 


### PR DESCRIPTION
As an alternative to using a fixed path to the Hadoop binary, we can start a login shell to use the configuration set on the profile.d scripts (set by the CERN Hadoop rpm).