### PR TITLE
Implement cron job and create html page for rucio datasets not read since N months

### DIFF
--- a/bin/cron4rucio_datasets_last_access_ts.sh
+++ b/bin/cron4rucio_datasets_last_access_ts.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Cron job of run_rucio_datasets_last_access_ts.py
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    cat <<EOF
+ Usage: .sh --html_directory <HTML_DIRECTORY> --output_dir <OUTPUT_DIR> --rses_pickle <RSES_PICKLE>
+    - This cron job produce rucio_dataset_last_access.html using Rucio table dumps in hdfs
+ Args:
+    - HTML_DIRECTORY: directory of partial html files used in html creation
+    - OUTPUT_DIR: directory of output html files
+    - RSES_PICKLE: Rucio rse name and id map pickle file, see ~/CMSSpark/static/rucio/rse_name_id_map_pickle.py
+
+EOF
+    exit 0
+fi
+
+# Setup envs for hadoop and spark. Tested with LCG_98python3
+source /cvmfs/sft.cern.ch/lcg/views/LCG_98python3/x86_64-centos7-gcc8-opt/setup.sh
+source /cvmfs/sft.cern.ch/lcg/etc/hadoop-confext/hadoop-swan-setconf.sh analytix
+
+# Check JAVA_HOME is set
+if [ -n "$JAVA_HOME" ]; then
+    if [ -e "/usr/lib/jvm/java-1.8.0" ]; then
+        export JAVA_HOME="/usr/lib/jvm/java-1.8.0"
+    elif ! (java -XX:+PrintFlagsFinal -version 2>/dev/null | grep -E -q 'UseAES\s*=\s*true'); then
+        (echo >&2 "This script requires a java version with AES enabled")
+        exit 1
+    fi
+fi
+
+# Check Kerberos ticket
+if ! klist -s; then
+    echo "There is not valid ticket yet"
+    kinit
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HTML_DIRECTORY="${1:-$SCRIPT_DIR/../src/html/rucio_datasets_last_access_ts}"
+OUTPUT_DIR="${1:-/eos/user/c/cmsmonit/www/rucio_datasets_not_read}"
+RSES_PICKLE="${1:-$SCRIPT_DIR/../static/rucio/rses.pickle}"
+
+PY_INPUT_ARGS=(
+    --html_directory "$HTML_DIRECTORY"
+    --output_dir "$OUTPUT_DIR"
+    --rses_pickle "$RSES_PICKLE"
+)
+
+(echo >&2 "Output html file: ${OUTPUT_DIR}")
+
+# Run
+spark-submit \
+    --master yarn \
+    --conf spark.driver.extraClassPath='/eos/project/s/swan/public/hadoop-mapreduce-client-core-2.6.0-cdh5.7.6.jar' \
+    --conf spark.executor.memory=8g \
+    --conf spark.executor.instances=30 \
+    --conf spark.executor.cores=4 \
+    --conf spark.driver.memory=8g \
+    --conf spark.ui.showConsoleProgress=false \
+    --packages org.apache.spark:spark-avro_2.11:2.4.3 \
+    "$SCRIPT_DIR/../src/python/CMSSpark/rucio_datasets_last_access_ts.py" "${PY_INPUT_ARGS[@]}"

--- a/src/html/rucio_datasets_last_access_ts/footer.html
+++ b/src/html/rucio_datasets_last_access_ts/footer.html
@@ -1,0 +1,56 @@
+    </div>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
+    <script>
+        $(document).ready(function () {
+            //
+            function toggleDetails(){
+                var tr = $(this).closest("tr");
+                sel_name = $(tr).find("td a.selname").text()
+                dataset_name = $(tr).find("td a.dataset").text()
+                d_class="details-show"
+                row = dt.row(tr)
+                if(!row.child.isShown())
+                {
+                    // html file name of a dataset name includes slash replaced with -_-,
+                    // so use that convention to reach fil name from dataset name
+                    sel_name_replaced = sel_name.replaceAll(/\//g, "-_-");
+                    $(tr).addClass(d_class)
+                    row.child("<div id='details_"+sel_name_replaced+"'>loading</div>").show()
+                    folder = "rsedetails"
+                    $.get(folder+"/dataset_"+sel_name_replaced+".html", function (response){
+                        var html = response;
+                        $("#details_"+sel_name_replaced).html(html);
+                    });
+                }else{
+                    $(tr).removeClass(d_class)
+                    row.child.hide()
+                }
+            }
+            $('table#dataframe thead tr').append('<th>dataset details</th>');
+            $('table#dataframe tbody tr').append('<td><button class="btn-details">+</button></td>');
+            //
+            var dt = $('#dataframe').DataTable( {
+                // To set total row to first
+                "orderCellsTop": true,
+                "dom": "lifrtip",
+                "order": [[ 3, "desc" ]],
+                "pageLength" : 10,
+                "scrollX": false,
+                language: {
+                    search: "_INPUT_",
+                    searchPlaceholder: "--- Search Dataset ---",
+                },
+            });
+            //
+            $('table#dataframe tbody tr').on('click','td button.btn-details',toggleDetails)
+            //
+            dt.on('draw', function(){
+                $('table#dataframe tbody tr').off('click').on('click','td button.btn-details',toggleDetails)
+            })
+            //
+        });
+    </script>
+</body>
+<!-- final -->
+</html>

--- a/src/html/rucio_datasets_last_access_ts/header.html
+++ b/src/html/rucio_datasets_last_access_ts/header.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="https://cdn.datatables.net/1.10.20/css/jquery.dataTables.min.css">
+<style>
+    .dataTables_filter input {
+      border: 7px solid Tomato;
+      width: 400px;
+      font-size: 16px;
+      font-weight: bold;
+    }
+    table td {
+	word-break: break-all;
+    }
+    table td:nth-child(n+2) {
+        text-align: right;
+    }
+    #dataframe-tiers table {
+      font-family: arial, sans-serif;
+      border-collapse: collapse;
+      width: 100%;
+    }
+    #dataframe-tiers td, th {
+      border: 1px solid #dddddd;
+      text-align: left;
+      padding: 8px;
+    }
+    #dataframe-tiers tr:nth-child(even) {
+      background-color: #dddddd;
+    }
+</style>
+</head>
+<body>
+    <div class="cms">
+        <img src="https://cds.cern.ch/record/1306150/files/cmsLogo_image.jpg"
+            alt="CMS" style="width: 5%; float:left">
+        <h3 style="width: 100%; float:right">
+            Rucio Datasets which are not read since N months and have size greater than 1.0TB in disk
+            <small>Last Update: UPDATE_TIME UTC</small>
+        </h3>
+    </div>
+    <div class="w3-container">
+    <ul class="w3-ul w3-small" style="width:100%;margin-left:2%">
+      <li class="w3-padding-small">
+        Please read the "Assumptions and explanations of Rucio tables" part in the source code:
+      </li>
+      <li class="w3-padding-small">
+        <a href="https://github.com/dmwm/CMSSpark/blob/master/src/python/CMSSpark/rucio_datasets_last_access_ts.py">
+                CMSSpark/rucio_datasets_last_access_ts.py</a></b>
+      </li>
+    </ul>
+    </div>
+    <div class="container" style="display:block; width:100%">

--- a/src/notebooks/rucio_datasets_last_access_ts.ipynb
+++ b/src/notebooks/rucio_datasets_last_access_ts.ipynb
@@ -55,8 +55,8 @@
     "pd.options.display.float_format = \"{:,.2f}\".format\n",
     "pd.set_option(\"display.max_colwidth\", None)\n",
     "\n",
-    "TODAY = \"2022-01-13\"\n",
-    "#TODAY = datetime.today().strftime('%Y-%m-%d')\n",
+    "#TODAY = \"2022-01-13\"\n",
+    "TODAY = datetime.today().strftime('%Y-%m-%d')\n",
     "HDFS_RUCIO_CONTENTS = f\"/project/awg/cms/rucio_contents/{TODAY}/part*.avro\"\n",
     "HDFS_RUCIO_DIDS = f\"/project/awg/cms/rucio_dids/{TODAY}/part*.avro\"\n",
     "HDFS_RUCIO_REPLICAS = f\"/project/awg/cms/rucio/{TODAY}/replicas/part*.avro\""
@@ -296,7 +296,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_df_f_rse_ts_size(df_replicas_j_dids):\n",
+    "def get_df_file_rse_ts_size(df_replicas_j_dids):\n",
     "    \"\"\"fsize_dids or fsize_replicas should not be null. Just combine them to fill file sizes.\n",
     "\n",
     "    Firstly, REPLICAS size value will be used. If there are files with no size values, DIDS size values will be used:\n",
@@ -704,7 +704,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_f_rse_ts_size = get_df_f_rse_ts_size(df_replicas_j_dids)\n",
+    "df_f_rse_ts_size = get_df_file_rse_ts_size(df_replicas_j_dids)\n",
     "df_f_rse_ts_size.limit(10).toPandas().tail(5)"
    ]
   },

--- a/static/rucio/rse_name_id_map_pickle.py
+++ b/static/rucio/rse_name_id_map_pickle.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# Main Author: David LANGE
+
+"""Creates pickle file rse name and id map, to be used in rucio_datasets_last_access_ts.py to get only DISK rse ids"""
+
+# Requirements:
+#    - Rucio cli setup: https://twiki.cern.ch/twiki/bin/view/CMS/Rucio
+#    - In most of the Virtual Machines we cannot run this file because it requires Rucio CLI setup.
+#    - Should be run manually
+
+import os
+import pickle
+from subprocess import Popen, PIPE
+
+
+def runCommand(command):
+    """Run subprocess"""
+    p = Popen(command, stdout=PIPE, stderr=PIPE, shell=True)
+    pipe = p.stdout.read()
+    errpipe = p.stderr.read()
+    tupleP = os.waitpid(p.pid, 0)
+    eC = tupleP[1]
+    return eC, pipe.decode(encoding='UTF-8'), errpipe.decode(encoding='UTF-8')
+
+
+rucio_list_comm = "rucio list-rses"
+ec, cOut, cErr = runCommand(rucio_list_comm)
+rses = {}
+for line in cOut.split():
+    rse = str(line.strip())
+    print(rse)
+    comm = "rucio-admin rse info " + rse
+    ec2, cOut2, cErr2 = runCommand(comm)
+    rse_id = None
+    for l2 in cOut2.split('\n'):
+        if "id: " in l2:
+            rse_id = l2.split()[1]
+            break
+    print(rse_id)
+    rses[rse] = rse_id
+
+# ATTENTION: Python2 do not support default protocol of Python3 which is 3
+# Pickle file "rses.pickle" will be writtent to current directory
+with open("rses.pickle", "wb+") as f:
+    pickle.dump(rses, f, protocol=2)


### PR DESCRIPTION
Now it's a production candidate with its html page.

- Explanations are added. Since procedure is complex, you may find lots of comments.
- Create html page with toggle button that shows RSEs of listed datasets that not read since N months
- Partial html files are separated from python code
- Since final dataset size is so big, I put 1.0TB limit and include only not read since 12 mohts (we can add 3 and 6 months later)
- Cron job is created (no run file, I think that only cron file is enough).
- Python script of David that produce Rucio id:map dict and its pickle is added. It'll run manually and written into static path (CMSSpark/static/rucio). The reason is this script needs Rucio CLI in lxplus and I could not setup Rucio CLI in our vocms (may be doable but I don't know).
