### PR TITLE
enables search url parameter in dataset monitoring

### DIFF
--- a/src/html/rucio_datasets_last_access_ts/footer.html
+++ b/src/html/rucio_datasets_last_access_ts/footer.html
@@ -1,6 +1,7 @@
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/buttons/2.2.2/js/dataTables.buttons.min.js"></script>
     <script>
         function explainFunction() {
           var x = document.getElementById("explanations");
@@ -41,17 +42,32 @@
             $('table#dataframe thead tr').append('<th>Details</th>');
             $('table#dataframe tbody tr').append('<td><button class="btn-details" style="border-color:#E5B6B6;">Show details</button></td>');
             //
+            var url = new URL(window.location.href);
+            var searchString = url.searchParams.get("search");
+            if (searchString == null){
+              searchString = ''
+            }
             var dt = $('#dataframe').DataTable( {
                 // To set total row to first
                 "orderCellsTop": true,
-                "dom": "lifrtip",
+                "dom": "lifBrtip",
                 "order": [[ 3, "desc" ]],
                 "pageLength" : 10,
                 "scrollX": false,
+                "oSearch": { "sSearch": searchString },
                 language: {
                     search: "_INPUT_",
                     searchPlaceholder: "--- Search Dataset ---",
                 },
+                buttons: [
+                    {
+                        text: 'Get search as link',
+                        action: function ( e, dt, node, config ) {
+                          url.searchParams.set('search', dt.search());
+                          window.location.replace(url.href);
+                        }
+                    }
+                ]
             });
             //
             $('table#dataframe tbody tr').on('click','td button.btn-details',toggleDetails)

--- a/src/html/rucio_datasets_last_access_ts/header.html
+++ b/src/html/rucio_datasets_last_access_ts/header.html
@@ -3,6 +3,8 @@
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://cdn.datatables.net/1.10.20/css/jquery.dataTables.min.css">
+<link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.2.2/css/buttons.dataTables.min.css">
+
 <style>
     body {
 	    font-family: 'Trebuchet MS', sans-serif;
@@ -45,6 +47,10 @@
     /* details */
     table tr td:nth-child(7) {
         white-space:nowrap;
+    }
+    /* button */
+    div.dt-buttons {
+      float: right;
     }
 </style>
 </head>


### PR DESCRIPTION
Enables pre-filling the search box in dataset monitoring pages using a url parameter.
i.e. https://cuzunogl.web.cern.ch/cuzunogl/rucio_test/datasets_not_read_since_6_months.html?search=cern