### PR TITLE
Improve rucio_datasets_daily_stats and write stats to eos

### DIFF
--- a/bin/cron4rucio_datasets_daily_stats.sh
+++ b/bin/cron4rucio_datasets_daily_stats.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
+##H Can only run in K8s
+##H
 ##H cron4rucio_datasets_daily_stats.sh
 ##H    Cron job of rucio_datasets_daily_stats.py which runs Sqoop dumps and send Spark agg results to MONIT via StompAMQ
 ##H    We need to run Sqoop dumps and Spark job sequentially.
@@ -7,12 +9,12 @@ set -e
 ##H
 ##H Usage:
 ##H    cron4rucio_datasets_daily_stats.sh \
-##H        <keytab> value <cmsr> value <rucio> value <amq> value <cmsmonitoring> value <stomp> value <k8s>
+##H        <keytab> value <cmsr> value <rucio> value <amq> value <cmsmonitoring> value <stomp> value <eos> value
 ##H
-##H Example to run in K8s:
+##H Example :
 ##H    cron4rucio_datasets_daily_stats.sh \
 ##H        --keytab ./keytab --cmsr ./cmsr_cstring --rucio ./rucio --amq ./amq-creds.json \
-##H        --cmsmonitoring ./CMSMonitoring.zip --stomp ./stomp-v700.zip --k8s
+##H        --cmsmonitoring ./CMSMonitoring.zip --stomp ./stomp-v700.zip --eos /eos/user/c/cmsmonit/www/rucio_test
 ##H
 ##H Arguments with values:
 ##H   - keytab                    : Kerberos auth file: secrets/kerberos
@@ -22,38 +24,18 @@ set -e
 ##H                                   secrets/cms-rucio-dailystats
 ##H   - cmsmonitoring             : dmwm/CMSMonitoring/src/python/CMSMonitoring folder as zip to be sent to Spark nodes
 ##H   - stomp                     : stomp.py==7.0.0 module as zip to be sent to Spark nodes which has lower versions.
-##H Arguments without values:
-##H   - k8s                       : [Optional] If script will run in K8s, should be set as `--k8s`
+##H   - eos                       : Base EOS directory to write datasets statistics in html format.
 ##H
 ##H References:
 ##H   - some features&logics are copied from sqoop_utils.sh and cms-dbs3-full-copy.sh
 ##H   - getopt ref: https://www.shellscript.sh/tips/getopt/index.html
 ##H
 
-# ---------------------------------------------------------------------------------------------------- Common functions
-# The tables of which split-by column set as Null and -m=1 are so small tables, no need to do parallel import
-RUCIO_TABLES_DICT="table split_column num_mappers
-REPLICAS,rse_id,40
-CONTENTS,Null,40
-RSES,Null,1"
-RUCIO_SCHEMA=CMS_RUCIO_PROD
-
-DBS_TABLES_DICT="table split_column num_mappers
-FILES,dataset_id,40
-DATASETS,dataset_id,4
-DATA_TIERS,Null,1
-PHYSICS_GROUPS,Null,1
-ACQUISITION_ERAS,Null,1
-DATASET_ACCESS_TYPES,Null,1"
-DBS_SCHEMA=CMS_DBS3_PROD_GLOBAL_OWNER
-
-TZ=UTC
-START_TIME=$(date +%s)
-
-SCRIPT_DIR="$(
-    cd -- "$(dirname "$0")" >/dev/null 2>&1
-    pwd -P
-)"
+trap 'onFailExit' ERR
+onFailExit() {
+    echo "$(date --rfc-3339=seconds)" "[ERROR] Finished with error!"
+    exit 1
+}
 usage() {
     perl -ne '/^##H/ && do { s/^##H ?//; print }' <"$0"
     exit 1
@@ -63,14 +45,19 @@ secs_to_human() {
     # Ref https://stackoverflow.com/a/59096583/6123088
     echo "$((${1} / 3600))h $(((${1} / 60) % 60))m $((${1} % 60))s"
 }
-trap 'onFailExit' ERR
-onFailExit() {
-    echo "$(date --rfc-3339=seconds)" "[ERROR] Finished with error!"
-    exit 1
-}
+SCRIPT_DIR="$(
+    cd -- "$(dirname "$0")" >/dev/null 2>&1
+    pwd -P
+)"
+TZ=UTC
+START_TIME=$(date +%s)
 
-# ------------------------------------------------------------------------------------------- Get arguments with getopt
-unset -v KEYTAB_SECRET CMSR_SECRET RUCIO_SECRET AMQ_JSON_CREDS CMSMONITORING_ZIP STOMP_ZIP IS_K8S help
+# Define logs path for Spark imports which produce lots of info logs
+LOG_DIR="$WDIR"/logs/$(date +%Y%m%d)
+mkdir -p "$LOG_DIR"
+
+# ------------------------------------------------------------------------------------------------------- GET USER ARGS
+unset -v KEYTAB_SECRET CMSR_SECRET RUCIO_SECRET AMQ_JSON_CREDS CMSMONITORING_ZIP STOMP_ZIP EOS_DIR help
 [ "$#" -ne 0 ] || usage
 
 # --options (short options) is mandatory, and v is a dummy param.
@@ -79,7 +66,7 @@ PARSED_ARGUMENTS=$(
         --unquoted \
         --options v \
         --name "$(basename -- "$0")" \
-        --longoptions keytab:,cmsr:,rucio:,amq:,cmsmonitoring:,stomp:,,help,k8s \
+        --longoptions keytab:,cmsr:,rucio:,amq:,cmsmonitoring:,stomp:,eos:,,help \
         -- "$@"
 )
 VALID_ARGUMENTS=$?
@@ -116,9 +103,9 @@ while [[ $# -gt 0 ]]; do
         STOMP_ZIP=$2
         shift 2
         ;;
-    --k8s)
-        IS_K8S=1
-        shift
+    --eos)
+        EOS_DIR=$2
+        shift 2
         ;;
     -h | --help)
         help=1
@@ -135,8 +122,7 @@ if [[ "$help" == 1 ]]; then
     usage
 fi
 
-# ------------------------------------------------------------------------------------ Checks parameters and input files
-# Required file checks
+# ------------------------------------------------------------------------------------------- CHECK IF FILES/DIRS EXIST
 for fname in $KEYTAB_SECRET $CMSR_SECRET $RUCIO_SECRET $AMQ_JSON_CREDS $CMSMONITORING_ZIP $STOMP_ZIP; do
     if [ ! -e "${BASE_SECRET_FILES_DIR}/${fname}" ]; then
         echo "$(date --rfc-3339=seconds)" "[ERROR] File does not exist: ${BASE_SECRET_FILES_DIR}/${fname}"
@@ -154,39 +140,23 @@ if [ -n "$JAVA_HOME" ]; then
     fi
 fi
 
-# -------------------------------------------------------------------------------------------------------- K8s settings
-# Check if K8s env vars are set, accordingly spark ports will be arranged
-if [[ "$IS_K8S" == 1 ]]; then
-    [[ -z "$MY_NODE_NAME" ]] && {
-        echo "ERROR: MY_NODE_NAME is not defined"
-        exit 1
-    }
-    [[ -z "$CMSMON_RUCIO_DS_SERVICE_PORT_PORT_0" ]] && {
-        echo "ERROR: CMSMON_RUCIO_DS_SERVICE_PORT_PORT_0 is not defined"
-        exit 1
-    }
-    [[ -z "$CMSMON_RUCIO_DS_SERVICE_PORT_PORT_1" ]] && {
-        echo "ERROR: CMSMON_RUCIO_DS_SERVICE_PORT_PORT_1 is not defined"
-        exit 1
-    }
-    [[ -z "$WDIR" ]] && {
-        echo "ERROR: WDIR is not defined"
-        exit 1
-    }
-    # Define logs path for Spark imports which produce lots of info logs
-    LOG_DIR="$WDIR"/logs/$(date +%Y%m%d)
-    mkdir -p "$LOG_DIR"
-
-    # Set analytix cluster settings, use spark3
-    hadoop-set-default-conf.sh analytix
-    source hadoop-setconf.sh analytix 3.2 spark3
-else
-    LOG_DIR="$SCRIPT_DIR"/logs/$(date +%Y%m%d)
-    mkdir -p "$LOG_DIR"
-
-    # Set analytix cluster settings, use spark3
-    source /cvmfs/sft.cern.ch/lcg/etc/hadoop-confext/hadoop-swan-setconf.sh analytix 3.2 spark3
-fi
+# ------------------------------------------------------------------------------------------------------ CHECK K8S ENVS
+[[ -z "$MY_NODE_NAME" ]] && {
+    echo "ERROR: MY_NODE_NAME is not defined"
+    exit 1
+}
+[[ -z "$CMSMON_RUCIO_DS_SERVICE_PORT_PORT_0" ]] && {
+    echo "ERROR: CMSMON_RUCIO_DS_SERVICE_PORT_PORT_0 is not defined, which is used for -spark.driver.port-"
+    exit 1
+}
+[[ -z "$CMSMON_RUCIO_DS_SERVICE_PORT_PORT_1" ]] && {
+    echo "ERROR: CMSMON_RUCIO_DS_SERVICE_PORT_PORT_1 is not defined, which used for -spark.driver.blockManager.port-"
+    exit 1
+}
+[[ -z "$WDIR" ]] && {
+    echo "ERROR: WDIR is not defined"
+    exit 1
+}
 
 # --------------------------------------------------------------------------------------------- Kerberos authentication
 PRINCIPAL=$(klist -k "$KEYTAB_SECRET" | tail -1 | awk '{print $2}')
@@ -197,19 +167,44 @@ if [ $? == 1 ]; then
     exit 1
 fi
 klist -k "$KEYTAB_SECRET"
-
-# -------------------------------------------------------------------------------------- Sqoop related global variables
 # Get Kerberos user name to use its /tmp HDFS directory as temporary folder
 KERBEROS_USER=$(echo "$PRINCIPAL" | grep -o '^[^@]*')
 
-# Use tmp hdfs directory to store table dumps
-SQOOP_DUMP_DIR_PREFIX=/tmp/${KERBEROS_USER}/rucio_daily_stats
-BASE_SQOOP_DUMP_DIR="$SQOOP_DUMP_DIR_PREFIX"-$(date +%Y-%m-%d)
+# Requires kerberos ticket to reach the EOS directory
+if [ ! -d "$EOS_DIR" ]; then
+    echo "$(date --rfc-3339=seconds)" "[ERROR] EOS directory does not exist: ${EOS_DIR}}"
+    exit 1
+fi
+# -------------------------------------------------------------------------------------------------------------- TABLES
+# The tables of which split-by column set as Null and -m=1 are so small tables, no need to do parallel import
+RUCIO_TABLES_DICT="table split_column num_mappers
+REPLICAS,rse_id,40
+CONTENTS,Null,40
+RSES,Null,1"
+RUCIO_SCHEMA=CMS_RUCIO_PROD
+
+DBS_TABLES_DICT="table split_column num_mappers
+FILES,dataset_id,40
+DATASETS,dataset_id,4
+DATA_TIERS,Null,1
+PHYSICS_GROUPS,Null,1
+ACQUISITION_ERAS,Null,1
+DATASET_ACCESS_TYPES,Null,1"
+DBS_SCHEMA=CMS_DBS3_PROD_GLOBAL_OWNER
 
 # DBS and Rucio use same jdbc url
 JDBC_URL=$(sed '1q;d' "$CMSR_SECRET")
 
-# ------------------------------------------------------------------------------------------------ Imports single table
+# ------------------------------------------------------------------------------------------------------------ HDFS DIR
+# Use tmp hdfs directory to store table dumps
+SQOOP_DUMP_DIR_PREFIX=/tmp/${KERBEROS_USER}/rucio_daily_stats
+BASE_SQOOP_DUMP_DIR="$SQOOP_DUMP_DIR_PREFIX"-$(date +%Y-%m-%d)
+
+# ------------------------------------------------------------------------------------------ INITIALIZE ANALYTIX SPARK3
+hadoop-set-default-conf.sh analytix
+source hadoop-setconf.sh analytix 3.2 spark3
+
+# ------------------------------------------------------------------------------------------------- IMPORT SINGLE TABLE
 function dump_single_table() {
     trap 'onFailExit' ERR
     local local_username=$1
@@ -246,7 +241,9 @@ function dump_single_table() {
     echo "$(date --rfc-3339=seconds)" [INFO] End: "$local_schema"."$local_table"
 }
 
-# ---------------------------------------------------------------------------- Imports DBS and Rucio tables in parallel
+# ------------------------------------------------------------------------------------------------ IMPORT RUCIO AND DBS
+# One each of Rucio or DBS at a time
+
 function import_rucio_tables() {
     trap 'onFailExit' ERR
     rucio_username=$(grep username <"$RUCIO_SECRET" | awk '{print $2}')
@@ -273,7 +270,7 @@ function import_dbs_tables() {
     } <<<"$DBS_TABLES_DICT"
 }
 
-# ------------------------------------------------------------------------------------------------------------ Main run
+# ------------------------------------------------------------------------------------------------------------ MAIN RUN
 
 import_rucio_tables 2>&1 &
 import_dbs_tables 2>&1 &
@@ -288,35 +285,10 @@ hadoop fs -rm -r -f -skipTrash "$path_of_yesterday"
 echo "$(date --rfc-3339=seconds)" "[INFO] Dump of yesterday is deleted ${path_of_yesterday}"
 echo "$(date --rfc-3339=seconds)" "[INFO] Dumps are finished. Time spent: $(secs_to_human "$(($(date +%s) - START_TIME))")"
 
-# ---------------------------------------------------------------------------------------------------------------------
-#                                           -- ========  Spark Job  ======== --
-
-if [[ -z "$IS_K8S" ]]; then
-    # Below operations are required to run this script in LxPlus environment. In K8s, we don't need since docker image provides all below.
-
-    # LCG_101 release setup gives py3.6 py3.9 driver-worker incompatibility error.
-    #   Virtual environment will be used until the issue is solved in upstream
-    #   Do not run `source /cvmfs/sft.cern.ch/lcg/views/LCG_101/x86_64-centos7-gcc8-opt/setup.sh`
-    /cvmfs/sft.cern.ch/lcg/releases/Python/3.6.5-f74f0/x86_64-centos7-gcc8-opt/bin/python3.6 -m venv venv_pyspark
-    source venv_pyspark/bin/activate
-    pip install --upgrade pip
-    pip install --no-cache-dir pandas click pyspark
-
-    # Create zip file of stomp.py 7.0.0
-    pip install --no-cache-dir -t stomp-v700 https://github.com/jasonrbriggs/stomp.py/archive/refs/tags/v7.0.0.zip
-    cd stomp-v700
-    zip -r ../stomp-v700.zip .
-    cd ..
-    rm -rf stomp-v700
-
-    # Zip file and directory of CMSMonitoring
-    svn export https://github.com/mrceyhun/CMSMonitoring.git/branches/f-stomp-v6+/src/python/CMSMonitoring
-    zip -r CMSMonitoring.zip CMSMonitoring/*
-    rm -rf CMSMonitoring
-fi
-
-# --------------------------------------------------------------------------------------- Run spark after sqoop imports
+# ------------------------------------------------------------------------------------------------------- RUN SPARK JOB
 function run_spark() {
+    # Required for Spark job in K8s
+    export SPARK_LOCAL_IP=127.0.0.1
     echo "$(date --rfc-3339=seconds)" "[INFO] Spark job starts"
     export PYTHONPATH=$SCRIPT_DIR/../src/python:$PYTHONPATH
     spark_submit_args=(
@@ -329,18 +301,17 @@ function run_spark() {
         --packages org.apache.spark:spark-avro_2.12:3.2.1
         --py-files "${CMSMONITORING_ZIP},${STOMP_ZIP}"
     )
-    # If it'll run in K8s, define Spark network settings in K8s cluster
-    if [[ "$IS_K8S" == 1 ]]; then
-        spark_submit_args+=(
-            --conf "spark.driver.bindAddress=0.0.0.0"
-            --conf "spark.driver.host=${MY_NODE_NAME}"
-            --conf "spark.driver.port=${CMSMON_RUCIO_DS_SERVICE_PORT_PORT_0}"
-            --conf "spark.driver.blockManager.port=${CMSMON_RUCIO_DS_SERVICE_PORT_PORT_1}"
-        )
-    fi
+    # Define Spark network settings in K8s cluster
+    spark_submit_args+=(
+        --conf "spark.driver.bindAddress=0.0.0.0"
+        --conf "spark.driver.host=${MY_NODE_NAME}"
+        --conf "spark.driver.port=${CMSMON_RUCIO_DS_SERVICE_PORT_PORT_0}"
+        --conf "spark.driver.blockManager.port=${CMSMON_RUCIO_DS_SERVICE_PORT_PORT_1}"
+    )
     py_input_args=(
         --creds "$AMQ_JSON_CREDS"
         --base_hdfs_dir "$BASE_SQOOP_DUMP_DIR"
+        --base_eos_dir "$EOS_DIR"
         --amq_batch_size 1000
     )
     # Run
@@ -353,5 +324,7 @@ function run_spark() {
 
 run_spark 2>&1
 
+echo "$(date --rfc-3339=seconds)" "[INFO] Last 10 lines of Spark job log"
+tail -10 "${LOG_DIR}/spark-job.log"
 # Print process wall clock time
 echo "$(date --rfc-3339=seconds)" "[INFO] All finished. Time spent: $(secs_to_human "$(($(date +%s) - START_TIME))")"

--- a/doc/scripts/cron4rucio_datasets_daily_stats.md
+++ b/doc/scripts/cron4rucio_datasets_daily_stats.md
@@ -1,0 +1,36 @@
+## CMSSpark/bin/cron4rucio_datasets_daily_stats.sh
+
+Dumps sqoop tables to temporary hdfs folder and then sends Spark job results to MONIT.
+
+To run in LxPlus, for the time that this script is created, you need below settings:
+
+```shell
+
+# Before running Sqoop and spark job, set analytix cluster settings, use spark3
+source /cvmfs/sft.cern.ch/lcg/etc/hadoop-confext/hadoop-swan-setconf.sh analytix 3.2 spark3
+
+
+# Below operations are required to run this script in LxPlus environment. 
+# In K8s, we don't need since docker image provides all below.
+
+# LCG_101 release setup gives py3.6 py3.9 driver-worker incompatibility error.
+#   Virtual environment will be used until the issue is solved in upstream
+#   Do not run `source /cvmfs/sft.cern.ch/lcg/views/LCG_101/x86_64-centos7-gcc8-opt/setup.sh`
+/cvmfs/sft.cern.ch/lcg/releases/Python/3.6.5-f74f0/x86_64-centos7-gcc8-opt/bin/python3.6 -m venv venv_pyspark
+source venv_pyspark/bin/activate
+pip install --upgrade pip
+pip install --no-cache-dir pandas click pyspark
+
+# Create zip file of stomp.py 7.0.0
+pip install --no-cache-dir -t stomp-v700 https://github.com/jasonrbriggs/stomp.py/archive/refs/tags/v7.0.0.zip
+cd stomp-v700
+zip -r ../stomp-v700.zip .
+cd ..
+rm -rf stomp-v700
+
+# Zip file and directory of CMSMonitoring
+svn export https://github.com/mrceyhun/CMSMonitoring.git/branches/f-stomp-v6+/src/python/CMSMonitoring
+zip -r CMSMonitoring.zip CMSMonitoring/*
+rm -rf CMSMonitoring
+
+```


### PR DESCRIPTION
- Since if else conditions make script so long, cron job is arranged to run only in K8s.
- Read me file is created to show how to run it in LxPlus `doc/scripts/cron4rucio_datasets_daily_stats.md`
- "Files are not in DBS or Rucio datasets" kind statistics are important. New function is created to write intermediate statistic results to EOS file. you can find in Grafana dashboard and also here: [https://cmsdatapop.web.cern.ch/cmsdatapop/rucio_daily_ds_stats/2022-04-18.html](https://cmsdatapop.web.cern.ch/cmsdatapop/rucio_daily_ds_stats/2022-04-18.html)
- Shell script line order is arranged for readability.
- After merge of this PR, it'll be deployed to cmsmonit cluster.