### PR TITLE
F improve spark

### DIFF
--- a/bin/cron4hpc_usage.sh
+++ b/bin/cron4hpc_usage.sh
@@ -10,7 +10,8 @@ set -e
 ##H
 ##H Script arguments:
 ##H    OUTPUT_DIR        Directory that output html files will be written
-##H    LAST_N_MONTHS     without providing start end date, selecting last N months data coverage
+##H    START_DATE        Start date of processed data
+##H    END_DATE          End date of processed data
 ##H    URL_PREFIX        CernBox EOS folder url link
 ##H
 
@@ -52,20 +53,24 @@ fi
 
 # Arg 1
 OUTPUT_DIR="${1:-/eos/user/c/cmsmonit/www/hpc_usage}"
-# Arg 2, default is 19 months
-LAST_N_MONTHS="${2:-19}"
-# Arg 3
-URL_PREFIX="${1:-https://cmsdatapop.web.cern.ch/cmsdatapop/hpc_usage}"
+# Arg 2, start date
+START_DATE="${2:-2020-01-01}"
+# Arg 3, end date
+END_DATE="${3:-$(date +"%Y-%m-%d")}"
+# Arg 4
+URL_PREFIX="${4:-https://cmsdatapop.web.cern.ch/cmsdatapop/hpc_usage}"
 HTML_TEMPLATE="$script_dir"/../src/html/hpc/html_template.html
 
 echo "output directory: ${OUTPUT_DIR}"
 
 # PySpark job args
 py_input_args=(
+    --start_date "$START_DATE"
+    --end_date "$END_DATE"
     --output_dir "$OUTPUT_DIR"
-    --last_n_months "$LAST_N_MONTHS"
     --url_prefix "$URL_PREFIX"
     --html_template "$HTML_TEMPLATE"
+    # --save_pickle default is True
 )
 spark_submit_args=(
     --master yarn
@@ -74,6 +79,7 @@ spark_submit_args=(
     --conf spark.executor.cores=4
     --conf spark.driver.memory=4g
     --conf spark.ui.showConsoleProgress=false
+    --conf spark.sql.session.timeZone=UTC
 )
 
 # Run

--- a/bin/cron4rucio_datasets_daily_stats.sh
+++ b/bin/cron4rucio_datasets_daily_stats.sh
@@ -293,10 +293,10 @@ function run_spark() {
     export PYTHONPATH=$SCRIPT_DIR/../src/python:$PYTHONPATH
     spark_submit_args=(
         --master yarn
-        --conf spark.executor.memory=4g
+        --conf spark.executor.memory=8g
         --conf spark.executor.instances=30
         --conf spark.executor.cores=4
-        --conf spark.driver.memory=4g
+        --conf spark.driver.memory=8g
         --conf spark.ui.showConsoleProgress=false
         --packages org.apache.spark:spark-avro_2.12:3.2.1
         --py-files "${CMSMONITORING_ZIP},${STOMP_ZIP}"

--- a/src/html/hpc/html_template.html
+++ b/src/html/hpc/html_template.html
@@ -2,10 +2,15 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.20/css/jquery.dataTables.min.css">
+    <!-- prepared using https://datatables.net/download/ -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/jq-3.6.0/jszip-2.5.0/dt-1.12.1/b-2.2.3/b-colvis-2.2.3/b-html5-2.2.3/b-print-2.2.3/cr-1.5.6/date-1.1.2/kt-2.7.0/rr-1.2.8/sc-2.0.6/sb-1.3.3/sp-2.0.1/sl-1.4.0/sr-1.1.1/datatables.min.css"/>
+
+    <!--  Please do not delete below CSSes, important for pretty view -->
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/dt/dt-1.12.1/datatables.min.css"/>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/1.11.4/css/dataTables.bootstrap.min.css">
     <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.2.2/css/buttons.bootstrap.min.css">
+
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <style>
         body {
@@ -15,7 +20,7 @@
         .dataTables_filter input {
           border: 7px solid Tomato;
           width: 400px;
-          font-size: 16px;
+          font-size: 14px;
           font-weight: bold;
         }
         table td {
@@ -42,6 +47,16 @@
         div.dt-buttons {
           float: right;
         }
+        .dt-button.buttons-columnVisibility.active {
+              background: #FF0000 !important;
+              color: white !important;
+              opacity: 0.5;
+           }
+        .dt-button.buttons-columnVisibility {
+              background: black !important;
+              color: white !important;
+              opacity: 1;
+           }
     </style>
 </head>
 <body>
@@ -66,22 +81,20 @@
     This page shows the monthly CoreHrs sum of HPC sites.
         </pre>
 	</div>
+  <div>
+    ____SITE_PLOT_URLS____
+  </div>
+  <div>
 
   ____MAIN_BLOCK____
 
   </div>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.5.1.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/1.11.4/js/jquery.dataTables.min.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/1.11.4/js/dataTables.bootstrap.min.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/buttons/2.2.2/js/dataTables.buttons.min.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/buttons/2.2.2/js/buttons.bootstrap.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/buttons/2.2.2/js/buttons.html5.min.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/buttons/2.2.2/js/buttons.print.min.js"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/buttons/2.2.2/js/buttons.colVis.min.js"></script>
+    <!-- prepared using https://datatables.net/download/ -->
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.36/pdfmake.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.36/vfs_fonts.js"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/v/dt/jqc-1.12.4/jszip-2.5.0/dt-1.12.1/af-2.4.0/b-2.2.3/b-colvis-2.2.3/b-html5-2.2.3/b-print-2.2.3/cr-1.5.6/date-1.1.2/fc-4.1.0/fh-3.2.3/r-2.3.0/sb-1.3.3/sp-2.0.1/sl-1.4.0/sr-1.1.1/datatables.min.js"></script>
+    <!-- Please do not delete below JS which is required for footerCallback-->
+    <script type="text/javascript" src="https://cdn.datatables.net/fixedheader/3.2.3/js/dataTables.fixedHeader.min.js"></script>
     <script>
         function explainFunction() {
           var x = document.getElementById("explanations");
@@ -110,7 +123,8 @@
                 {
                     $(tr).addClass(d_class)
                     row.child("<div id='details_"+month_name+"'>loading</div>").show()
-                    $.get(month_name+".html", function (response){
+                    // plots are in ./html subdirectory
+                    $.get("./html/"+month_name+".html", function (response){
                         var html = response;
                         $("#details_"+month_name).html(html);
                     });
@@ -134,19 +148,47 @@
                     searchPlaceholder: "--- Search Month ---",
                 },
                 lengthChange: false,
-                  buttons: [
-                  'copy',
-                  'excel',
-                  'pdf',
+                "footerCallback": function ( row, data, start, end, display ) {
+                    // Footer callback is used for calculating Totals
+                    var api = this.api(), data;
+                    api.columns('.sum', { page: 'current'}).every( function () {
+                      var sum = this
+                        .data()
+                        .reduce( function (a, b) {
+                            return parseInt(a) + parseInt(b);
+                        }, 0 );
+                        console.log(sum)
+                      this.footer().innerHTML = sum;
+                    } );
+                },
+                buttons: [
+                  {
+                    extend: 'copyHtml5',
+                    exportOptions: {
+                      columns: ':visible'
+                    }
+                  },
+                  {
+                    extend: 'excelHtml5',
+                    exportOptions: {
+                      columns: ':visible'
+                    }
+                  },
+                  {
+                    extend: 'pdfHtml5',
+                    exportOptions: {
+                      columns: ':visible'
+                    }
+                  },
                   'colvis',
                   {
-                        text: 'Copy search link to clipboard',
-                        action: function ( e, dt, node, config ) {
-                          url.searchParams.set('search', dt.search());
-                          //window.location.replace(url.href);
-                          navigator.clipboard.writeText(url.href);
-                        }
+                    text: 'Copy search link to clipboard',
+                    action: function ( e, dt, node, config ) {
+                      url.searchParams.set('search', dt.search());
+                      //window.location.replace(url.href);
+                      navigator.clipboard.writeText(url.href);
                     }
+                  },
                 ]
             });
             //

--- a/src/python/CMSSpark/hpc_running_cores_and_corehr.py
+++ b/src/python/CMSSpark/hpc_running_cores_and_corehr.py
@@ -14,7 +14,7 @@ from dateutil.relativedelta import relativedelta
 from pyspark import SparkContext
 from pyspark.sql import SparkSession
 from pyspark.sql.functions import (
-    col, concat_ws, from_unixtime, lit, unix_timestamp, when,
+    col, concat_ws, format_string, from_unixtime, lit, unix_timestamp, when,
     avg as _avg,
     dayofmonth as _dayofmonth,
     max as _max,
@@ -31,12 +31,14 @@ from pyspark.sql.types import (
     DoubleType,
 )
 
-global URL_PREFIX
 DEFAULT_HDFS_FOLDER = '/project/monitoring/archive/condor/raw/metric'
 
 # Bottom to top bar stack order which set same colors for same site always
 HPC_SITES_STACK_ORDER = ['ANL', 'BSC', 'CINECA', 'HOREKA', 'NERSC', 'OSG', 'PSC', 'RWTH', 'SDSC', 'TACC']
 VALID_DATE_FORMATS = ["%Y/%m/%d", "%Y-%m-%d", "%Y%m%d"]
+CSV_DIR = 'csv'
+HTML_DIR = 'html'
+SITES_HTML_DIR = 'site_htmls'
 
 
 def get_spark_session():
@@ -141,7 +143,7 @@ def process_and_get_pd_dfs(spark, start_date, end_date):
             _dayofmonth(col('date'))
         ).withColumn(
             'month',
-            concat_ws('-', _year(col('date')), _month(col('date')))
+            concat_ws('-', _year(col('date')), format_string('%02d', _month(col('date'))))  # 2-digit month, default 1
         ).drop(
             'Site', 'MachineAttrCMSSubSiteName0'
         ).withColumnRenamed('site_name', 'site')
@@ -174,103 +176,174 @@ def process_and_get_pd_dfs(spark, start_date, end_date):
     return df_core_hr_daily.toPandas(), df_running_cores_daily.toPandas(), df_core_hr_monthly.toPandas()
 
 
-def get_fig_core_hr_one_month(df_month, month, sites_stack_order, csv_fname):
-    """Creates plotly figure from one month of data for core hours"""
-    csv_link = f"{URL_PREFIX}/{csv_fname}"
+def get_fig_core_hr_daily_of_a_month(df_month, month, output_dir, url_prefix):
+    """Creates plotly figure from one month of data for daily core hours and write csv"""
+    csv_fname = month + '_core_hr.csv'
+    csv_output_path = os.path.join(os.path.join(output_dir, CSV_DIR), csv_fname)
+    csv_link = f"{url_prefix}/{CSV_DIR}/{csv_fname}"
     fig = px.bar(df_month, x="dayofmonth", y="sum CoreHr", color='site',
                  category_orders={
-                     'site': sites_stack_order,
+                     'site': HPC_SITES_STACK_ORDER,
                      'dayofmonth': [day for day in range(1, 32)]
                  },
-                 title='CoreHrs - ' + month,
+                 title='CoreHrs - ' + month +
+                       ' <b><a href="{}">[Source]</a></b>'.format(csv_link),
                  labels={
                      'sum CoreHr': 'CoreHr',
-                     'dayofmonth': 'date<br>Source: <b><a href="{}">{}</a></b>'.format(csv_link, csv_fname),
+                     'dayofmonth': 'date',
                  },
                  width=800, height=600,
                  )
     fig.update_xaxes(tickprefix=month + "-", tickangle=300, tickmode='linear')
     fig.update_yaxes(automargin=True, tickformat=".2f")
     fig.update_layout(hovermode='x')
+
+    # Write source data to csv
+    df_month.sort_values(by=['month', 'dayofmonth', 'site']).to_csv(csv_output_path, index=False)
     return fig
 
 
-def get_fig_running_cores_one_month(df_month, month, sites_stack_order, csv_fname):
-    """Creates plotly figure from one month of data for running cores"""
-    csv_link = f"{URL_PREFIX}/{csv_fname}"
+def get_fig_running_cores_daily_of_a_month(df_month, month, output_dir, url_prefix):
+    """Creates plotly figure from one month of data for daily running cores and write csv"""
+    csv_fname = month + '_running_cores.csv'
+    csv_output_path = os.path.join(os.path.join(output_dir, CSV_DIR), csv_fname)
+    csv_link = f"{url_prefix}/{CSV_DIR}/{csv_fname}"
     fig = px.bar(df_month, x="dayofmonth", y="running_cores_avg_over_12m_sum", color='site',
                  category_orders={
-                     'site': sites_stack_order,
+                     'site': HPC_SITES_STACK_ORDER,
                      'dayofmonth': [day for day in range(1, 32)]
                  },
-                 title="Running Cores avg of 12m sum - " + month,
+                 title='Running Cores avg of 12m sum - ' + month +
+                       ' <b><a href="{}">[Source]</a></b>'.format(csv_link),
                  labels={
                      'running_cores_avg_over_12m_sum': 'running_cores',
-                     'dayofmonth': 'date<br>Source: <b><a href="{}">{}</a></b>'.format(csv_link, csv_fname)
+                     'dayofmonth': 'date',
                  },
                  width=800, height=600,
-                 hover_data=['site', 'running_cores_avg_over_12m_sum'],
                  )
     fig.update_xaxes(tickprefix=month + "-", tickangle=300, tickmode='linear')
     fig.update_yaxes(automargin=True, tickformat=".2f")
     fig.update_layout(hovermode='x')
+
+    # Write source data to csv
+    df_month.sort_values(by=['month', 'dayofmonth', 'site']).to_csv(csv_output_path, index=False)
     return fig
 
 
-def get_fig_core_hr_monthly_all(df_all, sites_stack_order, sorted_months, csv_fname):
+def write_2_daily_plots_to_single_html_each_month(df_tmp_core_hr, df_tmp_running_cores, month, output_dir, url_prefix):
+    """Joins core_hr and running_cores plots in a single html side by side"""
+    # Get figures
+    fig1 = get_fig_core_hr_daily_of_a_month(df_month=df_tmp_core_hr, month=month, output_dir=output_dir,
+                                            url_prefix=url_prefix)
+    fig2 = get_fig_running_cores_daily_of_a_month(df_month=df_tmp_running_cores, month=month, output_dir=output_dir,
+                                                  url_prefix=url_prefix)
+    # Join 2 plots in one html to show CoreHr and running cores plots side-by-side on X-axis
+    html_head = '<head><style>#plot1, #plot2 {display: inline-block;width: 49%;}</style></head>'
+    fig1_div = '<div id="plot1">{}</div>'.format(fig1.to_html(full_html=False, include_plotlyjs='cdn'))
+    fig2_div = '<div id="plot2">{}</div>'.format(fig2.to_html(full_html=False, include_plotlyjs='cdn'))
+
+    html_output_file = os.path.join(os.path.join(output_dir, HTML_DIR), month + '.html')
+    with open(html_output_file, 'w') as f:
+        f.write(html_head + fig1_div + fig2_div)
+
+
+def handle_core_hr_monthly_sum_of_all(df_core_hr_monthly, sorted_months, output_dir, url_prefix):
     """Creates plotly figure from all data with monthly granularity for core hours"""
-    csv_link = f"{URL_PREFIX}/{csv_fname}"
-    fig = px.bar(df_all, x="month", y="sum CoreHr", color='site',
+    # Name is join of first and last month names of the used data
+    fname_pre = 'all_monthly_core_hr'
+    csv_output_path = os.path.join(output_dir, fname_pre + '.csv')
+    html_output_path = os.path.join(output_dir, fname_pre + '.html')
+    csv_link = f"{url_prefix}/{fname_pre}.csv"
+
+    fig = px.bar(df_core_hr_monthly, x="month", y="sum CoreHr", color='site',
                  category_orders={
-                     'site': sites_stack_order,
+                     'site': HPC_SITES_STACK_ORDER,
                      'month': sorted_months,
                  },
-                 title="CoreHrs - monthly sum",
+                 title='CoreHrs - monthly sum'
+                       + '<b><a href="{}">[Source]</a></b>'.format(csv_link),
                  labels={
                      'sum CoreHr': 'CoreHr',
-                     'month': 'date<br>Source: <b><a href="{}">{}</a></b>'.format(csv_link, csv_fname)
+                     'month': 'date'
                  },
                  width=800, height=600,
                  )
     fig.update_xaxes(dtick="M1", tickangle=300)
     fig.update_yaxes(automargin=True, tickformat=".2f")
     fig.update_layout(hovermode='x')
-    return fig
+
+    # Write html
+    with open(html_output_path, 'w') as f:
+        f.write(fig.to_html(full_html=True, include_plotlyjs='cdn'))
+    # Write source csv
+    df_core_hr_monthly.sort_values(by=['month', 'site']).to_csv(csv_output_path, index=False)
 
 
-def handle_monthly_results(df_tmp_core_hr, df_tmp_running_cores, month, output_dir):
-    """Writes raw csv data to file, creates plots in html with raw data link"""
-    core_hr_csv_fname = month + '_core_hr.csv'
-    r_cores_csv_fname = month + '_running_cores.csv'
+def handle_core_hr_monthly_sum_of_all_for_each_site(df_core_hr_monthly, sorted_months, output_dir):
+    """Creates plotly figure from all data with monthly granularity for core hours of each individual site"""
+    for site in HPC_SITES_STACK_ORDER:
+        df_tmp = df_core_hr_monthly[df_core_hr_monthly['site'] == site]
+        fig = px.bar(df_tmp, x="month", y="sum CoreHr",
+                     category_orders={
+                         'month': sorted_months,
+                     },
+                     title=site + ' - CoreHrs monthly sum',
+                     labels={
+                         'sum CoreHr': 'CoreHr',
+                         'month': 'date'
+                     },
+                     width=800, height=600,
+                     )
+        fig.update_xaxes(dtick="M1", tickangle=300)
+        fig.update_yaxes(automargin=True, tickformat=".2f")
+        fig.update_layout(hovermode='x')
+        # Write html
+        fname = site + '.html'
 
-    core_hr_csv_path = os.path.join(output_dir, core_hr_csv_fname)
-    r_cores_csv_path = os.path.join(output_dir, r_cores_csv_fname)
-
-    # Write to csv
-    df_tmp_core_hr.sort_values(by=['month', 'dayofmonth', 'site']).to_csv(core_hr_csv_path, index=False)
-    df_tmp_running_cores.sort_values(by=['month', 'dayofmonth', 'site']).to_csv(r_cores_csv_path, index=False)
-
-    # Get figures
-    fig1 = get_fig_core_hr_one_month(df_tmp_core_hr, month, HPC_SITES_STACK_ORDER, core_hr_csv_fname)
-    fig2 = get_fig_running_cores_one_month(df_tmp_running_cores, month, HPC_SITES_STACK_ORDER, r_cores_csv_fname)
-
-    # to show CoreHr and running cores plots side-by-side on X-axis
-    html_head = '<head><style>#plot1, #plot2 {display: inline-block;width: 49%;}</style></head>'
-    fig1_div = '<div id="plot1">{}</div>'.format(fig1.to_html(full_html=False, include_plotlyjs='cdn'))
-    fig2_div = '<div id="plot2">{}</div>'.format(fig2.to_html(full_html=False, include_plotlyjs='cdn'))
-    with open(os.path.join(output_dir, month + '.html'), 'w') as f:
-        f.write(html_head + fig1_div + fig2_div)
+        html_output_path = os.path.join(os.path.join(output_dir, SITES_HTML_DIR), fname)
+        with open(html_output_path, 'w') as f:
+            f.write(fig.to_html(full_html=True, include_plotlyjs='cdn'))
 
 
-def create_main_html(df_core_hr_monthly, html_template, output_dir):
+def prepare_site_urls(url_prefix):
+    """Prepares site plot links"""
+    html_div_site_links_block = ""
+    for site in HPC_SITES_STACK_ORDER:
+        site_plot_url = f"{url_prefix}/{SITES_HTML_DIR}/{site}.html"
+        html_a_template = f'<a href="{site_plot_url}" target="_blank">{site}</a> '
+        html_div_site_links_block += html_a_template
+    return html_div_site_links_block
+
+
+def add_footer(html):
+    """Footer calculation for total row, requires adding html elements"""
+    # Add footer for total
+    current_str = '''</thead>
+  <tbody>'''
+    replace_str = f'''</thead>
+  <tfoot>
+    <tr >
+      <th>TOTAL</th>
+      {"".join(f"<th>{site}</th>" for site in HPC_SITES_STACK_ORDER)}
+    </tr>
+  </tfoot>
+<tbody>'''
+    html = html.replace(current_str, replace_str)
+    return html
+
+
+def create_main_html(df_core_hr_monthly, html_template, output_dir, url_prefix):
     """Creates main.html that shows monthly CoreHrs sums and embedded plots using datatable"""
     # Rows to columns
     df = pd.pivot_table(df_core_hr_monthly, values='sum CoreHr', index=['month'],
                         columns=['site'])
-    # Remove column level
-    df = df.reset_index()
+    # Remove column level and fill null values with 0
+    df = df.reset_index().fillna(0)
     # Remove named column
     df.columns.name = None
+
+    # Convert columns to integer values.
+    df[HPC_SITES_STACK_ORDER] = df[HPC_SITES_STACK_ORDER].astype(int)
 
     main_column = df.month
     # To define selected column in JS, we need specific class name
@@ -283,30 +356,44 @@ def create_main_html(df_core_hr_monthly, html_template, output_dir):
         'table id="dataframe" class="display compact" style="width:100%;"',
     )
     html = html.replace('style="text-align: right;"', "")
+    for site in HPC_SITES_STACK_ORDER:
+        html = html.replace(f'<th>{site}</th>', f'<th class="sum">{site}</th>')
+
+    html = add_footer(html)
 
     with open(html_template) as f:
         template = f.read()
 
     current_date = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-    main_html = template.replace("___UPDATE_TIME___", current_date).replace("____MAIN_BLOCK____", html)
+    main_html = template.replace("___UPDATE_TIME___", current_date) \
+        .replace("____SITE_PLOT_URLS____", prepare_site_urls(url_prefix)) \
+        .replace("____MAIN_BLOCK____", html)
 
     with open(os.path.join(output_dir, 'main.html'), "w+") as f:
         f.write(main_html)
 
 
 @click.command()
-@click.option("--start_date", type=click.DateTime(VALID_DATE_FORMATS))
-@click.option("--end_date", type=click.DateTime(VALID_DATE_FORMATS))
-@click.option("--output_dir", default="./www/hpc_monthly", help="local output directory")
-@click.option("--last_n_months", type=int, default=19, help="Last n months data will be used")
+@click.option("--output_dir", required=True, default="./www/hpc_monthly", help="local output directory")
+@click.option("--start_date", required=False, type=click.DateTime(VALID_DATE_FORMATS))
+@click.option("--end_date", required=False, type=click.DateTime(VALID_DATE_FORMATS))
+@click.option("--last_n_months", required=False, type=int, default=19, help="Last n months data will be used")
 @click.option("--url_prefix", default="https://cmsdatapop.web.cern.ch/cmsdatapop/hpc_usage",
               help="CernBox eos folder link, will be used in plots to point to csv source data")
-@click.option('--html_template', default=None, type=str, required=True,
+@click.option('--html_template', required=True, default=None, type=str,
               help='Path of htmltemplate.html file: ~/CMSSpark/src/html/hpc/htmltemplate.html')
-def main(start_date, end_date, output_dir, last_n_months, url_prefix, html_template):
-    global URL_PREFIX
-    URL_PREFIX = url_prefix.strip("/")  # no slash at the end
+@click.option('--save_pickle', required=False, default=True, type=bool,
+              help='Stores df_core_hr_daily, df_running_cores_daily, df_core_hr_monthly to output_dir as pickle')
+def main(start_date, end_date, output_dir, last_n_months, url_prefix, html_template, save_pickle):
+    # Create subdirectories if does not exist
+    os.makedirs(os.path.join(output_dir, CSV_DIR), exist_ok=True)
+    os.makedirs(os.path.join(output_dir, HTML_DIR), exist_ok=True)
+    os.makedirs(os.path.join(output_dir, SITES_HTML_DIR), exist_ok=True)
+
+    url_prefix = url_prefix.strip("/")  # no slash at the end
     spark = get_spark_session()
+    # Set TZ as UTC. Also set in the spark-submit confs.
+    spark.conf.set("spark.sql.session.timeZone", "UTC")
 
     # HDFS .tmp folders can be in 1 day ago, so 2 days ago is selected for latest end date
     _2_days_ago = datetime.combine(date.today() - timedelta(days=2), datetime.min.time())
@@ -318,7 +405,7 @@ def main(start_date, end_date, output_dir, last_n_months, url_prefix, html_templ
         n_months_ago = end_date - relativedelta(months=last_n_months)
         start_date = datetime(year=n_months_ago.year, month=n_months_ago.month, day=1)
     elif not end_date:
-        end_date = min(start_date + relativedelta(months=last_n_months), _2_days_ago)
+        end_date = _2_days_ago
     if start_date > end_date:
         raise ValueError(
             f"start date ({start_date}) should be earlier than end date({end_date})"
@@ -328,34 +415,40 @@ def main(start_date, end_date, output_dir, last_n_months, url_prefix, html_templ
     # Get pandas dataframes
     df_core_hr_daily, df_running_cores_daily, df_core_hr_monthly = process_and_get_pd_dfs(spark, start_date, end_date)
 
+    # Save pickle files
+    if save_pickle:
+        df_core_hr_daily.to_pickle('core_hr_daily.pkl')
+        df_running_cores_daily.to_pickle('running_cores_daily.pkl')
+        df_core_hr_monthly.to_pickle('core_hr_monthly.pkl')
+        # df_core_hr_daily = pd.read_pickle("core_hr_daily.pkl")
+
     # Set date order of yyyy-mm month strings
-    sorted_months = sorted(df_core_hr_daily.month.unique(), key=lambda m: datetime.strptime(m, "%Y-%M"))
+    sorted_months = sorted(df_core_hr_daily.month.unique(), key=lambda m: datetime.strptime(m, "%Y-%m"))
 
     # Write plots that have daily granularity for each month
     for month in sorted_months:
         # Get temporary data frames
         df_tmp_core_hr = df_core_hr_daily[df_core_hr_daily['month'] == month]
         df_tmp_running_cores = df_running_cores_daily[df_running_cores_daily['month'] == month]
-        #
-        handle_monthly_results(df_tmp_core_hr, df_tmp_running_cores, month, output_dir)
+        write_2_daily_plots_to_single_html_each_month(df_tmp_core_hr=df_tmp_core_hr,
+                                                      df_tmp_running_cores=df_tmp_running_cores,
+                                                      month=month, output_dir=output_dir, url_prefix=url_prefix)
+
+    # Full data of monthly sum core hr
+    handle_core_hr_monthly_sum_of_all(df_core_hr_monthly=df_core_hr_monthly, sorted_months=sorted_months,
+                                      output_dir=output_dir, url_prefix=url_prefix)
+    # Create individual plots for each site
+    handle_core_hr_monthly_sum_of_all_for_each_site(df_core_hr_monthly=df_core_hr_monthly, sorted_months=sorted_months,
+                                                    output_dir=output_dir)
+    # Create main html
+    create_main_html(df_core_hr_monthly=df_core_hr_monthly, html_template=html_template, output_dir=output_dir,
+                     url_prefix=url_prefix)
 
     # Write whole core hr and running cores daily data to csv
     df_core_hr_daily.sort_values(by=['month', 'dayofmonth', 'site']) \
-        .to_csv(os.path.join(output_dir, 'all_core_hours.csv'), index=False)
+        .to_csv(os.path.join(output_dir, 'all_core_hr_daily.csv'), index=False)
     df_running_cores_daily.sort_values(by=['month', 'dayofmonth', 'site']) \
-        .to_csv(os.path.join(output_dir, 'all_running_cores.csv'), index=False)
-
-    # Core Hrs monthly ops, to csv and plot
-    monthly_core_hr_fname_prefix = 'monthly_core_hr_' + '_'.join(sorted_months[:2])
-    monthly_core_hr_path_prefix = os.path.join(output_dir, monthly_core_hr_fname_prefix)
-    df_core_hr_monthly.sort_values(by=['month', 'site']).to_csv(monthly_core_hr_path_prefix + '.csv', index=False)
-    fig3 = get_fig_core_hr_monthly_all(df_core_hr_monthly, HPC_SITES_STACK_ORDER, sorted_months,
-                                       monthly_core_hr_fname_prefix + '.csv')
-    with open(os.path.join(output_dir, monthly_core_hr_path_prefix + '.html'), 'w') as f:
-        f.write(fig3.to_html(full_html=True, include_plotlyjs='cdn'))
-
-    # Create main html
-    create_main_html(df_core_hr_monthly, html_template, output_dir)
+        .to_csv(os.path.join(output_dir, 'all_running_cores_daily.csv'), index=False)
 
 
 if __name__ == "__main__":

--- a/src/python/CMSSpark/hpc_running_cores_and_corehr.py
+++ b/src/python/CMSSpark/hpc_running_cores_and_corehr.py
@@ -263,7 +263,7 @@ def handle_monthly_results(df_tmp_core_hr, df_tmp_running_cores, month, output_d
 
 
 def create_main_html(df_core_hr_monthly, html_template, output_dir):
-    """Creates index.html that shows monthly CoreHrs sums and embedded plots using datatable"""
+    """Creates main.html that shows monthly CoreHrs sums and embedded plots using datatable"""
     # Rows to columns
     df = pd.pivot_table(df_core_hr_monthly, values='sum CoreHr', index=['month'],
                         columns=['site'])
@@ -290,7 +290,7 @@ def create_main_html(df_core_hr_monthly, html_template, output_dir):
     current_date = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
     main_html = template.replace("___UPDATE_TIME___", current_date).replace("____MAIN_BLOCK____", html)
 
-    with open(os.path.join(output_dir, 'index.html'), "w+") as f:
+    with open(os.path.join(output_dir, 'main.html'), "w+") as f:
         f.write(main_html)
 
 


### PR DESCRIPTION
- Increase the "Rucio daily datasets stats" Spark job executor/driver memory to 8g which fixes the Spark resource allocation problem that we lived recently.
- Improve [HPC usage page](https://cmsdatapop.web.cern.ch/cmsdatapop/hpc_usage/main.html):
  - Fix Column visibility bug and make it colorfull
  - Change 1 digit month format to 2 digit format which will fix month sorting on the page
  - Improve export options with new libraries
  - Add Total row using footerCallback, which is responsive to filters.
  - Add individual plots for each Site with a link for them at the top of the page.
  - Fix raw source link in the plots and make plot labels prettier than before.
