### PR TITLE
Apply check utilities to cron jobs

### DIFF
--- a/bin/cron4crab_unique_users.sh
+++ b/bin/cron4crab_unique_users.sh
@@ -109,3 +109,11 @@ ln -s -f "$OUTPUT_DIR/UniqueUsersBy_weekofyear_$(date -d "$START_DATE" +%Y%m%d)-
 
 duration=$(($(date +%s) - START_TIME))
 util4logi "all finished, time spent: $(util_secs_to_human $duration)"
+
+# ---------------------------------------------------------------------------------------------------------------- TEST
+# This cron job runs monthly, so last modification date of the output should be within 32 days
+time_threshold=2764800
+size_threshold=10000 # (10KB)
+
+/bin/bash "$script_dir/utils/check_utils.sh" check_file_status "$OUTPUT_DIR/UniqueUsersBy_month_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).png" $time_threshold $size_threshold
+# Running commands after this point will change the exit code.

--- a/bin/cron4dbs_condor
+++ b/bin/cron4dbs_condor
@@ -94,4 +94,23 @@ function func() {
     fi
 }
 
-$cmd >>$log 2>&1
+$cmd >> $log 2>&1
+
+# ---------------------------------------------------------------------------------------------------------------- TEST
+# This cron job runs daily, so last modification date of the output should be within 12 hours
+time_threshold=43200
+# Size thresholds
+campaign=200000000 # (20MB)
+dataset=200000000 # (20MB)
+era=100000 # (100KB)
+release=100000 # (100KB)
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+date_hdfs=$(date -d "yesterday" '+%Y/%m/%d')
+
+set -e
+/bin/bash  "$script_dir/utils/check_utils.sh" check_hdfs "$odir/campaign/$date_hdfs" $time_threshold $campaign
+/bin/bash  "$script_dir/utils/check_utils.sh" check_hdfs "$odir/dataset/$date_hdfs" $time_threshold $dataset
+/bin/bash  "$script_dir/utils/check_utils.sh" check_hdfs "$odir/era/$date_hdfs" $time_threshold $era
+/bin/bash  "$script_dir/utils/check_utils.sh" check_hdfs "$odir/release/$date_hdfs" $time_threshold $release
+# Running commands after this point will change the exit code.

--- a/bin/cron4dbs_condor_df
+++ b/bin/cron4dbs_condor_df
@@ -81,3 +81,12 @@ function func() {
         fi
     fi
 }
+
+# ---------------------------------------------------------------------------------------------------------------- TEST
+# This cron job runs daily, so last modification date of the output should be within 12 hours
+time_threshold=43200
+size_threshold=25000000 # (25MB)
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+/bin/bash "$script_dir/utils/check_utils.sh" check_file_status "$fout" $time_threshold $size_threshold
+# Running commands after this point will change the exit code.

--- a/bin/cron4dbs_events
+++ b/bin/cron4dbs_events
@@ -60,3 +60,12 @@ function func() {
 }
 
 $cmd >> $log 2>&1
+
+# ---------------------------------------------------------------------------------------------------------------- TEST
+# This cron job runs daily, so last modification date of the output should be within 12 hours
+time_threshold=43200
+size_threshold=25000000 # (25MB)
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+/bin/bash "$script_dir/utils/check_utils.sh" check_file_status "$odir/dbs_events.csv.gz" $time_threshold $size_threshold
+# Running commands after this point will change the exit code.

--- a/bin/cron4gen_crsg_plots.sh
+++ b/bin/cron4gen_crsg_plots.sh
@@ -133,10 +133,22 @@ if [[ "$IS_TEST" == 1 ]]; then
     start_month=$(date -d "$(date) -3 month" +%Y/%m)
     gen_plot "F10" "$start_month"
     gen_plot "F9" "$start_month"
+    file_to_test="event_count_$(date -d "-3 month" +"%Y%m")-$(date -d "-1 month" +"%Y%m").png"
 else
     gen_plot "F10"
     gen_plot "F9"
+    file_to_test="event_count_$(date -d "-1 year" +"%Y%m")-$(date -d "-1 month" +"%Y%m").png"
 fi
 
 duration=$(($(date +%s) - START_TIME))
 util4logi "all finished, time spent: $(util_secs_to_human $duration)"
+
+# ---------------------------------------------------------------------------------------------------------------- TEST
+# This cron job runs monthly, so last modification date of the output should be within 32 days
+time_threshold=2764800
+size_threshold=10000 # (10KB)
+
+set -e
+/bin/bash "$script_dir/utils/check_utils.sh" check_file_status "$OUTPUT_DIR/F9/$file_to_test" $time_threshold $size_threshold
+/bin/bash "$script_dir/utils/check_utils.sh" check_file_status "$OUTPUT_DIR/F10/$file_to_test" $time_threshold $size_threshold
+# Running commands after this point will change the exit code.

--- a/bin/cron4hs06_cputime_plot.sh
+++ b/bin/cron4hs06_cputime_plot.sh
@@ -121,3 +121,13 @@ ln -s -f "$OUTPUT_DIR/T1/HS06CpuTimeHr_weekofyear_$(date -d "$START_DATE" +%Y%m%
 
 duration=$(($(date +%s) - START_TIME))
 util4logi "all finished, time spent: $(util_secs_to_human $duration)"
+
+# ---------------------------------------------------------------------------------------------------------------- TEST
+# This cron job runs monthly, so last modification date of the output should be within 32 days
+time_threshold=2764800
+size_threshold=10000 # (10KB)
+
+set -e
+/bin/bash "$script_dir/utils/check_utils.sh" check_file_status "$OUTPUT_DIR/T1/HS06CpuTimeHr_weekofyear_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).png" $time_threshold $size_threshold
+/bin/bash "$script_dir/utils/check_utils.sh" check_file_status "$OUTPUT_DIR/T2/HS06CpuTimeHr_weekofyear_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).png" $time_threshold $size_threshold
+# Running commands after this point will change the exit code.

--- a/bin/cron4rucio_daily.sh
+++ b/bin/cron4rucio_daily.sh
@@ -75,3 +75,13 @@ py_input_args=(--verbose --output "$OUTPUT_DIR" --fdate "$current_date")
 
 # log all to stdout
 spark-submit "${spark_submit_args[@]}" "$script_dir/../src/python/CMSSpark/rucio_daily.py" "${py_input_args[@]}" 2>&1
+
+# ---------------------------------------------------------------------------------------------------------------- TEST
+# This cron job runs daily, so last modification date of the output should be within 12 hours
+time_threshold=43200
+# Average directory size is 80 Mb, so 50 Mb can be given as the size threshold
+size_threshold=50000000
+current_date_hdfs="$(date +%Y/%m/%d)"
+
+/bin/bash "$script_dir/utils/check_utils.sh" check_hdfs "$OUTPUT_DIR/rucio/$current_date_hdfs" $time_threshold $size_threshold
+# Running commands after this point will change the exit code.

--- a/bin/degraded/cron_crab_unique_users.sh
+++ b/bin/degraded/cron_crab_unique_users.sh
@@ -31,3 +31,10 @@ ln -s -f "$OUTPUT_DIR/UniqueUsersBy_month_$(date -d "$START_DATE" +%Y%m%d)-$(dat
 
 ln -s -f "$OUTPUT_DIR/UniqueUsersBy_weekofyear_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).csv" "$OUTPUT_DIR/UniqueUsersBy_weekofyear_latest.csv"
 ln -s -f "$OUTPUT_DIR/UniqueUsersBy_weekofyear_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).png" "$OUTPUT_DIR/UniqueUsersBy_weekofyear_latest.png"
+
+# ----- CRON SUCCESS CHECK -----
+# This cron job generates a plot every month, so time treshold should be 32 days
+TIME_TRESHOLD=2764800
+SIZE_TRESHOLD=10000 # (10KB)
+
+/bin/bash "$SCRIPT_DIR"/utils/check_utils.sh check_file_status "$OUTPUT_DIR/UniqueUsersBy_month_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).png" $TIME_TRESHOLD $SIZE_TRESHOLD

--- a/bin/degraded/cron_genCRSGplots.sh
+++ b/bin/degraded/cron_genCRSGplots.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Generate the plots for the CRSG report
-# In the following parameters comment the parameter if you want to use the default value. 
-# using an empty array will set the parameter without value. 
+# In the following parameters comment the parameter if you want to use the default value.
+# using an empty array will set the parameter without value.
 #
 # PARAMETERS FIGURE 9
 F9_TIERS=("GEN" "GEN-SIM" "GEN-RAW" "GEN-SIM-RECO" "AODSIM" "MINIAODSIM" "RAWAODSIM" "NANOAODSIM" "GEN-SIM-DIGI-RAW" "GEN-SIM-RAW" "GEN-SIM-DIGI-RECO")
@@ -15,6 +15,7 @@ F10_REMOVE=("test" "backfill" "StoreResults" "monitor" "Error/" "Scouting" "Mini
 
 # DO NOT MODIFY AFTER THIS COMMENT
 BASE_OUTPUT_FOLDER="${1:-./output}"
+echo "OUTPUT TO $BASE_OUTPUT_FOLDER"
 OUTPUT_FORMAT="${2:-png}"
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 ADDITIONAL_PARAMS="${@:3}"
@@ -33,8 +34,22 @@ function gen_plot() {
     REMOVE_PAR=$([[ -v "$REMOVE_VAR" ]]&&echo "--remove ${!REMOVE_EXPAND}"||echo "")
     IMAGE=$(/bin/bash "$script_dir/generate_event_count_plot.sh" --attributes $ATTRIBUTES_FILE --output_folder "$BASE_OUTPUT_FOLDER/$PREFIX" --output_format "$OUTPUT_FORMAT" $TIERS_PAR $SKIMS_PAR $REMOVE_PAR $ADDITIONAL_PARAMS)
     echo "$IMAGE"
-    ln -sf "$IMAGE" "$BASE_OUTPUT_FOLDER/$PREFIX/event_count_latest.$OUTPUT_FORMAT" 
+    ln -sf "$IMAGE" "$BASE_OUTPUT_FOLDER/$PREFIX/event_count_latest.$OUTPUT_FORMAT"
 }
 
 gen_plot "F10"
 gen_plot "F9"
+
+# ----- CRON SUCCESS CHECK -----
+# This cron job updates yearly plots every month, so treshold should be 32 days
+TIME_TRESHOLD=2764800
+# 00 14 05 * * /bin/bash $HOME/CMSSpark/bin/cron_genCRSGplots.sh /eos/user/c/cmsmonit/www/EventCountPlots
+SIZE_TRESHOLD=10000 # (10KB)
+FILE_TO_CHECK="event_count_$(date -d "1 year ago" +"%Y%m")-$(date -d "1 month ago" +"%Y%m").png" # generate name of the files we are testing
+
+trap 'EC'=210 ERR
+
+/bin/bash "$SCRIPT_DIR"/utils/check_utils.sh check_file_status "$BASE_OUTPUT_FOLDER/F9/$FILE_TO_CHECK" $TIME_TRESHOLD $SIZE_TRESHOLD || EC=$?
+/bin/bash "$SCRIPT_DIR"/utils/check_utils.sh check_file_status "$BASE_OUTPUT_FOLDER/F10/$FILE_TO_CHECK" $TIME_TRESHOLD $SIZE_TRESHOLD || EC=$?
+exit $EC
+# RUNNING COMMANDS AFTER THIS POINT WILL CHANGE EXIT CODE

--- a/bin/degraded/cron_hs06cputime_plot.sh
+++ b/bin/degraded/cron_hs06cputime_plot.sh
@@ -39,3 +39,16 @@ ln -s -f "$OUTPUT_DIR/T1/HS06CpuTimeHr_month_$(date -d "$START_DATE" +%Y%m%d)-$(
 ln -s -f "$OUTPUT_DIR/T1/HS06CpuTimeHr_month_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).png" "$OUTPUT_DIR/T1/HS06CpuTimeHr_month_latest.png"
 ln -s -f "$OUTPUT_DIR/T1/HS06CpuTimeHr_weekofyear_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).csv" "$OUTPUT_DIR/T1/HS06CpuTimeHr_weekofyear_latest.csv"
 ln -s -f "$OUTPUT_DIR/T1/HS06CpuTimeHr_weekofyear_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).png" "$OUTPUT_DIR/T1/HS06CpuTimeHr_weekofyear_latest.png"
+
+
+# ----- CRON SUCCESS CHECK -----
+# This cron job generates a plot monthly, so time treshold should be 32 days
+TIME_TRESHOLD=2764800
+# 30 14 19 * * /bin/bash $HOME/CMSSpark/bin/cron_hs06cputime_plot.sh /eos/user/c/cmsmonit/www/hs06cputime
+SIZE_TRESHOLD=10000 # (10KB)
+
+trap 'EC'=210 ERR
+/bin/bash "$SCRIPT_DIR"/utils/check_utils.sh check_file_status "$OUTPUT_DIR/T1/HS06CpuTimeHr_month_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).png" $TIME_TRESHOLD $SIZE_TRESHOLD || EC=$?
+/bin/bash "$SCRIPT_DIR"/utils/check_utils.sh check_file_status "$OUTPUT_DIR/T2/HS06CpuTimeHr_month_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).png" $TIME_TRESHOLD $SIZE_TRESHOLD || EC=$?
+exit $EC
+# RUNNING COMMANDS AFTER THIS POINT WILL CHANGE EXIT CODE


### PR DESCRIPTION
#99 
Progress:
- [x] cron4rucio_daily.sh - Changed sourcing check_utils.sh in cron4rucio_daily.sh to directly calling it as it caused exit code to be 0 in each case.
- [x] cron4dbs_condor - Won't work properly until we fix #104, it's also good to refactor how exit codes are handled
- [x] cron4dbs_condor_df - Many of the recently generated datasets appear to be empty, it's important to know why
- [x] cron4dbs_events 
- [ ] backfill_dbs_condor.sh 
- [ ] cron4aggregation 
- [ ] cron4rucio_datasets_last_access_ts.sh (datasets_never_read.html >500kb, <12h
- [ ] cron_CRAbpopularity.sh (CRAB_popularity_*-*_top_jc.png <32d)
- [x] cron_crab_unique_users.sh (UniqueUsersBy_weekofyear_*-*.png <32d)
- [x] cron_genCRSGplots.sh (F10/event_count_*-*.png, F9/event_count_*-*.png, <32d)
- [ ] cron_hpc_at_cms.sh (HPC@CMS_Running_Cores_hourly_*-*.png, <32d)
- [x] cron_hs06cputime_plot.sh (HS06CpuTimeHr_weekofyear_*-*.png, <32d)

Notes: 
cron4dbs_* succesfully tested with python 3 and LCG_96python3
