### PR TITLE
 Implement gh workflow to build docker images

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,89 @@
+# Builds and publish cmsmon-rucio-ds and condor-cpu-eff docker images
+name: Build docker images
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  build:
+    name: Build cmsmon-rucio-ds docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get git tag
+        id: get_tag
+        run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+
+      - name: Build cmsmon-rucio-ds image
+        run: |
+          echo Image tag: ${{ steps.get_tag.outputs.tag }}
+          curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/cmsmon-rucio-ds/Dockerfile
+          sed -i -e "s,ENV CMSMON_TAG=.*,ENV CMSMON_TAG=${{steps.get_tag.outputs.tag}},g" Dockerfile
+          docker build . --tag docker.pkg.github.com/dmwm/cmsmon-rucio-ds/cmsmon-rucio-ds
+          docker tag docker.pkg.github.com/dmwm/cmsmon-rucio-ds/cmsmon-rucio-ds registry.cern.ch/cmsmonitoring/cmsmon-rucio-ds
+
+      - name: Login to registry.cern.ch
+        uses: docker/login-action@v2
+        with:
+          registry: registry.cern.ch
+          username: ${{ secrets.CERN_LOGIN }}
+          password: ${{ secrets.CERN_TOKEN }}
+
+      - name: Publish cmsmon-rucio-ds image to registry.cern.ch
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.CERN_LOGIN }}
+          password: ${{ secrets.CERN_TOKEN }}
+          registry: registry.cern.ch
+          repository: cmsmonitoring/cmsmon-rucio-ds
+          tag_with_ref: true
+
+      - name: Build condor-cpu-eff image
+        run: |
+          echo Image tag: ${{ steps.get_tag.outputs.tag }}
+          curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/condor-cpu-eff/Dockerfile
+          sed -i -e "s,ENV CMSMON_TAG=.*,ENV CMSMON_TAG=${{steps.get_tag.outputs.tag}},g" Dockerfile
+          docker build . --tag docker.pkg.github.com/dmwm/condor-cpu-eff/condor-cpu-eff
+          docker tag docker.pkg.github.com/dmwm/condor-cpu-eff/condor-cpu-eff registry.cern.ch/cmsmonitoring/condor-cpu-eff
+
+      - name: Login to registry.cern.ch
+        uses: docker/login-action@v2
+        with:
+          registry: registry.cern.ch
+          username: ${{ secrets.CERN_LOGIN }}
+          password: ${{ secrets.CERN_TOKEN }}
+
+      - name: Publish condor-cpu-eff image to registry.cern.ch
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.CERN_LOGIN }}
+          password: ${{ secrets.CERN_TOKEN }}
+          registry: registry.cern.ch
+          repository: cmsmonitoring/condor-cpu-eff
+          tag_with_ref: true
+
+      - name: Build cmsmon-rucio-spark2mng image
+        run: |
+          echo Image tag: ${{ steps.get_tag.outputs.tag }}
+          curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/cmsmon-rucio-spark2mng/Dockerfile
+          sed -i -e "s,ENV CMSMON_TAG=.*,ENV CMSMON_TAG=${{steps.get_tag.outputs.tag}},g" Dockerfile
+          docker build . --tag docker.pkg.github.com/dmwm/cmsmon-rucio-spark2mng/cmsmon-rucio-spark2mng
+          docker tag docker.pkg.github.com/dmwm/cmsmon-rucio-spark2mng/cmsmon-rucio-spark2mng registry.cern.ch/cmsmonitoring/cmsmon-rucio-spark2mng
+
+      - name: Login to registry.cern.ch
+        uses: docker/login-action@v2
+        with:
+          registry: registry.cern.ch
+          username: ${{ secrets.CERN_LOGIN }}
+          password: ${{ secrets.CERN_TOKEN }}
+
+      - name: Publish cmsmon-rucio-spark2mng to registry.cern.ch
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.CERN_LOGIN }}
+          password: ${{ secrets.CERN_TOKEN }}
+          registry: registry.cern.ch
+          repository: cmsmonitoring/cmsmon-rucio-spark2mng
+          tag_with_ref: true


### PR DESCRIPTION
Implement docker image build by GH workflow for `cmsmon-rucio-ds`, `condor-cpu-eff` and  `cmsmon-rucio-spark2mng` docker images. Related PR [dmwm/CMSKubernetes/pull/1176](https://github.com/dmwm/CMSKubernetes/pull/1176)