### PR TITLE
Fix refactors

### DIFF
--- a/bin/cron4crab_popularity.sh
+++ b/bin/cron4crab_popularity.sh
@@ -73,13 +73,7 @@ util4logi "authenticated with Kerberos user: ${KERBEROS_USER}"
 
 # Check and set OUTPUT_DIR
 if [[ -n "$OUTPUT_DIR" ]]; then
-    if [ ! -d "$OUTPUT_DIR" ]; then
-        util4logw "output directory does not exist, creating..: ${OUTPUT_DIR}}"
-        if [ "$(mkdir -p "$OUTPUT_DIR" >/dev/null)" -ne 0 ]; then
-            util4loge "cannot create output directory: ${OUTPUT_DIR}"
-            exit 1
-        fi
-    fi
+    util_check_and_create_dir "$OUTPUT_DIR"
 else
     OUTPUT_DIR=$HOME/output
 fi

--- a/bin/cron4crab_unique_users.sh
+++ b/bin/cron4crab_unique_users.sh
@@ -73,13 +73,7 @@ util4logi "authenticated with Kerberos user: ${KERBEROS_USER}"
 
 # Check and set OUTPUT_DIR
 if [[ -n "$OUTPUT_DIR" ]]; then
-    if [ ! -d "$OUTPUT_DIR" ]; then
-        util4logw "output directory does not exist, creating..: ${OUTPUT_DIR}}"
-        if [ "$(mkdir -p "$OUTPUT_DIR" >/dev/null)" -ne 0 ]; then
-            util4loge "cannot create output directory: ${OUTPUT_DIR}"
-            exit 1
-        fi
-    fi
+    util_check_and_create_dir "$OUTPUT_DIR"
 else
     OUTPUT_DIR=$HOME/output_crab_uu
 fi

--- a/bin/cron4eos_dataset.sh
+++ b/bin/cron4eos_dataset.sh
@@ -71,13 +71,7 @@ util4logi "authenticated with Kerberos user: ${KERBEROS_USER}"
 
 # Check and set OUTPUT_DIR
 if [[ -n "$OUTPUT_DIR" ]]; then
-    if [ ! -d "$OUTPUT_DIR" ]; then
-        util4logw "output directory does not exist, creating..: ${OUTPUT_DIR}}"
-        if [ "$(mkdir -p "$OUTPUT_DIR" >/dev/null)" -ne 0 ]; then
-            util4loge "cannot create output directory: ${OUTPUT_DIR}"
-            exit 1
-        fi
-    fi
+    util_check_and_create_dir "$OUTPUT_DIR"
 else
     OUTPUT_DIR=$HOME/output_crab_uu
 fi

--- a/bin/cron4gen_crsg_plots.sh
+++ b/bin/cron4gen_crsg_plots.sh
@@ -72,13 +72,7 @@ util4logi "authenticated with Kerberos user: ${KERBEROS_USER}"
 
 # Check and set OUTPUT_DIR
 if [[ -n "$OUTPUT_DIR" ]]; then
-    if [ ! -d "$OUTPUT_DIR" ]; then
-        util4logw "output directory does not exist, creating..: ${OUTPUT_DIR}}"
-        if [ "$(mkdir -p "$OUTPUT_DIR" >/dev/null)" -ne 0 ]; then
-            util4loge "cannot create output directory: ${OUTPUT_DIR}"
-            exit 1
-        fi
-    fi
+    util_check_and_create_dir "$OUTPUT_DIR"
 else
     OUTPUT_DIR=$HOME/output
 fi

--- a/bin/cron4hpc_at_cms.sh
+++ b/bin/cron4hpc_at_cms.sh
@@ -8,7 +8,7 @@ set -e
 ##H    cron4hpc_at_cms.sh --keytab ./keytab --output <DIR> --p1 32000 --p2 32001 --host $MY_NODE_NAME --wdir $WDIR
 ##H Arguments:
 ##H   - keytab             : Kerberos auth file: secrets/keytab
-##H   - output             : Output directory. If not given, $HOME/output_hpc_at_cms will be used. I.e /eos/user/c/cmsmonit/www/crabPop/data
+##H   - output             : Output directory. If not given, $HOME/output_hpc_at_cms will be used. I.e /eos/user/c/cmsmonit/www/hpc
 ##H   - p1, p2, host, wdir : [ALL FOR K8S] p1 and p2 spark required ports(driver and blockManager), host is k8s node dns alias, wdir is working directory
 ##H   - test               : Flag that will process 2 months of data instead of 1 year.
 ##H How to test:
@@ -71,13 +71,7 @@ util4logi "authenticated with Kerberos user: ${KERBEROS_USER}"
 
 # Check and set OUTPUT_DIR
 if [[ -n "$OUTPUT_DIR" ]]; then
-    if [ ! -d "$OUTPUT_DIR" ]; then
-        util4logw "output directory does not exist, creating..: ${OUTPUT_DIR}}"
-        if [ "$(mkdir -p "$OUTPUT_DIR" >/dev/null)" -ne 0 ]; then
-            util4loge "cannot create output directory: ${OUTPUT_DIR}"
-            exit 1
-        fi
-    fi
+    util_check_and_create_dir "$OUTPUT_DIR"
 else
     OUTPUT_DIR=$HOME/output_hpc_at_cms
 fi

--- a/bin/cron4hpc_usage.sh
+++ b/bin/cron4hpc_usage.sh
@@ -6,7 +6,7 @@ set -e
 ##H Usage: cron4hpc_usage.sh <ARGS>
 ##H Example :
 ##H    cron4hpc_usage.sh \
-##H        --keytab ./keytab --output /eos/user/c/cmsmonit/www/foo --url https://cmsdatapop.web.cern.ch/cmsdatapop/hpc_usage \
+##H        --keytab ./keytab --output /eos/user/c/cmsmonit/www/hpc_usage --url https://cmsdatapop.web.cern.ch/cmsdatapop/hpc_usage \
 ##H        --p1 32000 --p2 32001 --host $MY_NODE_NAME --wdir $WDIR
 ##H        --iterative
 ##H Arguments:
@@ -83,13 +83,8 @@ KERBEROS_USER=$(util_kerberos_auth_with_keytab "$KEYTAB_SECRET")
 util4logi "authenticated with Kerberos user: ${KERBEROS_USER}"
 
 # Requires kerberos ticket to reach the EOS directory
-if [ ! -d "$OUTPUT_DIR" ]; then
-    util4logw "EOS directory does not exist, creating..: ${OUTPUT_DIR}}"
-    if [ "$(mkdir -p "$OUTPUT_DIR" >/dev/null)" -ne 0 ]; then
-        util4loge "cannot create output directory: ${OUTPUT_DIR}"
-        exit 1
-    fi
-fi
+util_check_and_create_dir "$OUTPUT_DIR"
+
 # ----------------------------------------------------------------------------------------------------------------- RUN
 util4logi "output directory: ${OUTPUT_DIR}"
 util4logi "spark job starting.."

--- a/bin/cron4hs06_cputime_plot.sh
+++ b/bin/cron4hs06_cputime_plot.sh
@@ -73,13 +73,7 @@ util4logi "authenticated with Kerberos user: ${KERBEROS_USER}"
 
 # Check and set OUTPUT_DIR
 if [[ -n "$OUTPUT_DIR" ]]; then
-    if [ ! -d "$OUTPUT_DIR" ]; then
-        util4logw "output directory does not exist, creating..: ${OUTPUT_DIR}}"
-        if [ "$(mkdir -p "$OUTPUT_DIR" >/dev/null)" -ne 0 ]; then
-            util4loge "cannot create output directory: ${OUTPUT_DIR}"
-            exit 1
-        fi
-    fi
+    util_check_and_create_dir "$OUTPUT_DIR"
 else
     OUTPUT_DIR=$HOME/output_hs06_cpu
 fi

--- a/bin/utils/common_utils.sh
+++ b/bin/utils/common_utils.sh
@@ -1,20 +1,27 @@
 #!/bin/bash
 
+#######################################
 # info log function
+#######################################
 util4logi() {
     echo "$(date --rfc-3339=seconds) [INFO]" "$@"
 }
 
+#######################################
 # warn log function
+#######################################
 util4logw() {
     echo "$(date --rfc-3339=seconds) [WARN]" "$@"
 }
 
+#######################################
 # error log function
+#######################################
 util4loge() {
     echo "$(date --rfc-3339=seconds) [ERROR]" "$@"
 }
 
+#######################################
 # util to convert seconds to h, m, s format used in logging
 #  Arguments:
 #    $1: seconds in integer
@@ -23,22 +30,28 @@ util4loge() {
 #    util_secs_to_human 1000 # returns: 0h 16m 40s
 #  Returns:
 #    '[\d+]h [\d+]m [\d+]s' , assuming [\d+] integer values
+#######################################
 util_secs_to_human() {
     echo "$((${1} / 3600))h $(((${1} / 60) % 60))m $((${1} % 60))s"
 }
 
+#######################################
 # util to print help message
+#######################################
 util_usage_help() {
     grep "^##H" <"$0" | sed -e "s,##H,,g"
     exit 0
 }
 
+#######################################
 # util to exit function on fail
+#######################################
 util_on_fail_exit() {
     util4loge "finished with error!"
     exit 1
 }
 
+#######################################
 # Util to check variables are defined
 #  Arguments:
 #    $1: variable name(s), meaning without $ sign. Supports multiple values
@@ -47,6 +60,7 @@ util_on_fail_exit() {
 #  Returns:
 #    success: 0
 #    fail   : exits with exit-code 1
+#######################################
 util_check_vars() {
     local var_check_flag var_names
     unset var_check_flag
@@ -58,6 +72,7 @@ util_check_vars() {
     return 0
 }
 
+#######################################
 # Util to check file exists
 #  Arguments:
 #    $1: file(s), full paths or names in current directory. Supports multiple files
@@ -66,6 +81,7 @@ util_check_vars() {
 #  Returns:
 #    success: 0
 #    fail   : exits with exit-code 1
+#######################################
 util_check_files() {
     local var_check_flag file_names
     unset var_check_flag
@@ -77,6 +93,7 @@ util_check_files() {
     return 0
 }
 
+#######################################
 # Util to check shell command or executable exists
 #  Arguments:
 #    $1: command/executable name or full path
@@ -85,6 +102,7 @@ util_check_files() {
 #  Returns:
 #    success: 0 and info log
 #    fail   : exits with exit-code 1
+#######################################
 util_check_cmd() {
     if which "$1" >/dev/null; then
         util4logi "$1 exists"
@@ -93,7 +111,30 @@ util_check_cmd() {
     fi
 }
 
+#######################################
+# Util to check if directory exist and create if not
+#  Arguments:
+#    $1: directory path
+#  Usage:
+#    util_check_cmd /dir/foo
+#  Returns:
+#    success: 0 and info log
+#    fail   : exits with exit-code 1
+#######################################
+util_check_and_create_dir() {
+    local dir=$1
+    if [ ! -d "$dir" ]; then
+        util4logw "output directory does not exist, creating..: ${dir}}"
+        if [[ "$(mkdir -p "$dir" >/dev/null)" -ne 0 ]]; then
+            util4loge "cannot create output directory: ${dir}"
+            exit 1
+        fi
+    fi
+}
+
+#######################################
 # check and set JAVA_HOME
+#######################################
 util_set_java_home() {
     if [ -n "$JAVA_HOME" ]; then
         if [ -e "/usr/lib/jvm/java-1.8.0" ]; then
@@ -105,6 +146,7 @@ util_set_java_home() {
     fi
 }
 
+#######################################
 # Util to authenticate with keytab and to return Kerberos principle name
 #  Arguments:
 #    $1: keytab file
@@ -113,6 +155,7 @@ util_set_java_home() {
 #  Returns:
 #    success: principle name before '@' part. If principle is 'johndoe@cern.ch, will return 'johndoe'
 #    fail   : exits with exit-code 1
+#######################################
 util_kerberos_auth_with_keytab() {
     local principle
     principle=$(klist -k "$1" | tail -1 | awk '{print $2}')
@@ -125,7 +168,9 @@ util_kerberos_auth_with_keytab() {
     echo "$principle" | grep -o '^[^@]*'
 }
 
+#######################################
 # setup hadoop and spark in k8s
+#######################################
 util_setup_spark_k8s() {
     # check hava home
     util_set_java_home
@@ -136,7 +181,9 @@ util_setup_spark_k8s() {
     export PYSPARK_PYTHON=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.6-b0f98/x86_64-centos7-gcc8-opt/bin/python3
 }
 
+#######################################
 # setup hadoop and spark in lxplus
+#######################################
 util_setup_spark_lxplus7() {
     # check hava home
     util_set_java_home

--- a/src/python/CMSSpark/dbs_hdfs_crab.py
+++ b/src/python/CMSSpark/dbs_hdfs_crab.py
@@ -156,14 +156,14 @@ def generate_top_datasets_plot(pdf, output_folder, filename):
 @click.option("--start_date", type=click.DateTime(_VALID_DATE_FORMATS))
 @click.option("--end_date", type=click.DateTime(_VALID_DATE_FORMATS))
 @click.option("--generate_plots", default=False, is_flag=True, help="Additional to the csv, generate the plot(s)")
-@click.option("--output", default="./output", help="local output directory")
-def main(start_date, end_date, output, generate_plots=False):
+@click.option("--output_folder", default="./output", help="local output directory")
+def main(start_date, end_date, output_folder, generate_plots=False):
     cp_pdf = get_crab_popularity_ds(start_date, end_date)
-    os.makedirs(output, exist_ok=True)
+    os.makedirs(output_folder, exist_ok=True)
     filename = f"CRAB_popularity_{start_date.strftime('%Y%m%d')}-{end_date.strftime('%Y%m%d')}"
-    cp_pdf.to_csv(os.path.join(output, f"{filename}.csv"))
+    cp_pdf.to_csv(os.path.join(output_folder, f"{filename}.csv"))
     if generate_plots:
-        generate_top_datasets_plot(cp_pdf, output, filename)
+        generate_top_datasets_plot(cp_pdf, output_folder, filename)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Couple of small things are fixed and new util is added for directory check/create.

I'm continuing to test each cron job. Except for `cron4hpc_usage.sh`, they can be test easily. That one requires to setup cern personal webpage to test,  a bit work is needed there.

I'm planning to create a K8s pod to test them. It will allow us to test our cron job automatically before running it in prod and we'll get rid of manually test. It will not a fast test though, even with test improvements (`--test` arg), they take approximately half and hour. Thinking about it..

Here is how they can be test:
```
cern_user=cuzunogl
base_eos_dir=/eos/user/${cern_user:0:1}/$cern_user/www/k8s-test/$(date +%Y-%m-%d)
common_args=(--test --keytab /etc/secrets/keytab --p1 31201 --p2 31202 --host $MY_NODE_NAME --wdir $WDIR)

cron4crab_popularity.sh "${common_args[@]}" --output  $base_eos_dir/crabPop/data
cron4crab_unique_users.sh "${common_args[@]}" --output  $base_eos_dir/crab_uu
cron4eos_dataset.sh "${common_args[@]}" --output  $base_eos_dir/EOS/data
cron4gen_crsg_plots.sh "${common_args[@]}" --output  $base_eos_dir/EventCountPlots
cron4hpc_at_cms.sh "${common_args[@]}" --output  $base_eos_dir/hpc
cron4hpc_usage.sh "${common_args[@]}" --output  $base_eos_dir/hpc_usage --url https://"$cern_user".web.cern.ch/"$cern_user"/hpc_usage
cron4hs06_cputime_plot.sh "${common_args[@]}" --output  $base_eos_dir/hs06cputime
cron4rucio_daily.sh "${common_args[@]}" --output /tmp/$cern_user
```
