### PR TITLE
Fix fetching hdfs files util function and help message

### DIFF
--- a/bin/cron4rucio_ds_summary.sh
+++ b/bin/cron4rucio_ds_summary.sh
@@ -10,7 +10,7 @@ set -e
 ##H        <keytab> value <amq> value <cmsmonitoring> value <stomp> value
 ##H
 ##H Example :
-##H    cron4rucio_datasets_daily_stats.sh \
+##H    cron4rucio_ds_summary.sh \
 ##H        --keytab ./keytab --amq ./amq-creds.json --cmsmonitoring ./CMSMonitoring.zip --stomp ./stomp-v700.zip \
 ##H        --p1 32000 --p2 32001 --host $MY_NODE_NAME --wdir $WDIR
 ##H Arguments with values:

--- a/src/python/CMSSpark/spark_utils.py
+++ b/src/python/CMSSpark/spark_utils.py
@@ -784,7 +784,7 @@ def get_candidate_files(start_date, end_date, spark, base, day_delta=1):
     # but if we are looking at recent days the compaction procedure could
     # have not run yet so we will considerate also the .tmp folders.
     candidate_files = [
-        f"{base}/{(st_date + timedelta(days=i)).strftime('%Y/%m/%d')}{{,.tmp}}"
+        f"{base}/{(st_date + timedelta(days=i)).strftime('%Y/%m/%d')}"
         for i in range(0, days)
     ]
     fsystem = sc._gateway.jvm.org.apache.hadoop.fs.FileSystem


### PR DESCRIPTION
We should not include HDFS `.tmp` folders/files which breaks spark job. `get_candidate_files` util function is used in most of the spark jobs.