### PR TITLE
Replace databricks avro lib package with official spark avro

### DIFF
--- a/src/python/CMSSpark/rucio_all_datasets.py
+++ b/src/python/CMSSpark/rucio_all_datasets.py
@@ -46,7 +46,7 @@ pd.set_option('display.max_colwidth', None)
 def get_df_rses(spark):
     """Get pandas dataframe of RSES
     """
-    df_rses = spark.read.format("com.databricks.spark.avro").load(HDFS_RUCIO_RSES) \
+    df_rses = spark.read.format("avro").load(HDFS_RUCIO_RSES) \
         .filter(col('DELETED_AT').isNull()) \
         .withColumn('rse_id', lower(_hex(col('ID')))) \
         .withColumn('rse_tier', _split(col('RSE'), '_').getItem(0)) \

--- a/src/python/CMSSpark/rucio_all_detailed_datasets.py
+++ b/src/python/CMSSpark/rucio_all_detailed_datasets.py
@@ -51,7 +51,7 @@ SYNC_PREFIX = 'sync'
 def get_df_rses(spark):
     """Create rucio RSES table dataframe with some rse tag calculations
     """
-    return spark.read.format("com.databricks.spark.avro").load(HDFS_RUCIO_RSES) \
+    return spark.read.format("avro").load(HDFS_RUCIO_RSES) \
         .filter(col('DELETED_AT').isNull()) \
         .withColumn('rse_id', lower(_hex(col('ID')))) \
         .withColumn('rse_tier', _split(col('RSE'), '_').getItem(0)) \

--- a/src/python/CMSSpark/rucio_datasets_daily_stats.py
+++ b/src/python/CMSSpark/rucio_datasets_daily_stats.py
@@ -109,7 +109,7 @@ def create_main_df(spark, hdfs_paths, base_eos_dir):
     #                -- ==================  Prepare main Spark dataframes  ===========================
 
     # Get RSES id, name, type, tier, country, kind from RSES table dump
-    df_rses = spark.read.format("com.databricks.spark.avro").load(hdfs_paths['RSES']) \
+    df_rses = spark.read.format("avro").load(hdfs_paths['RSES']) \
         .filter(col('DELETED_AT').isNull()) \
         .withColumn('replica_rse_id', lower(_hex(col('ID')))) \
         .withColumnRenamed('RSE', 'rse') \
@@ -124,7 +124,7 @@ def create_main_df(spark, hdfs_paths, base_eos_dir):
         .select(['replica_rse_id', 'rse', 'rse_type', 'rse_tier', 'rse_country', 'rse_kind'])
 
     # Rucio Dataset(D) refers to dbs block, so we used DBS terminology from the beginning
-    df_contents_f_to_b = spark.read.format("com.databricks.spark.avro").load(hdfs_paths['CONTENTS']) \
+    df_contents_f_to_b = spark.read.format("avro").load(hdfs_paths['CONTENTS']) \
         .filter(col("SCOPE") == "cms") \
         .filter(col("DID_TYPE") == "D") \
         .filter(col("CHILD_TYPE") == "F") \
@@ -134,7 +134,7 @@ def create_main_df(spark, hdfs_paths, base_eos_dir):
 
     # Rucio Dataset(D) refers to dbs block; Rucio Container(C) refers to dbs dataset.
     # We used DBS terminology from the beginning
-    df_contents_b_to_d = spark.read.format("com.databricks.spark.avro").load(hdfs_paths['CONTENTS']) \
+    df_contents_b_to_d = spark.read.format("avro").load(hdfs_paths['CONTENTS']) \
         .filter(col("SCOPE") == "cms") \
         .filter(col("DID_TYPE") == "C") \
         .filter(col("CHILD_TYPE") == "D") \

--- a/src/python/CMSSpark/rucio_ds_summary.py
+++ b/src/python/CMSSpark/rucio_ds_summary.py
@@ -67,7 +67,7 @@ NULL_STR_TYPE_COLUMN_VALUE = 'UNKNOWN'
 def get_df_rses(spark):
     """Get pandas dataframe of RSES
     """
-    df_rses = spark.read.format("com.databricks.spark.avro").load(HDFS_RUCIO_RSES) \
+    df_rses = spark.read.format("avro").load(HDFS_RUCIO_RSES) \
         .filter(col('DELETED_AT').isNull()) \
         .withColumn('rse_id', lower(_hex(col('ID')))) \
         .withColumn('rse_tier', _split(col('RSE'), '_').getItem(0)) \


### PR DESCRIPTION
Starting with Spark 2.4, databricks avro is not required and it is archived by the developers, see [databricks/spark-avro](https://github.com/databricks/spark-avro). Databricks avro is replaced with official Spark avro in latest spark3 jobs.