### PR TITLE
Add cmsmon-hdfs docker image build gh action which will be new base for cronjobs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,6 +24,6 @@ management of GitHub actions.
         - `Build docker (cmsmon-rucio-ds) SOME COMMENTS`
         - `Build docker (cmsmon-rucio-spark2mng, condor-cpu-eff)`
         - `Build docker (cmsmon-rucio-spark2mng, condor-cpu-eff) foo foo`
-
+        - `Build docker (cmsmon-hdfs) to fix foo`
 
 > Docker images use `cmsmon-hadoop-base:spark3-latest` as base image. Therefore, that image:tag should be updated regularly (i.e. in each quarter).

--- a/.github/workflows/build-docker-spark.yml
+++ b/.github/workflows/build-docker-spark.yml
@@ -135,3 +135,31 @@ jobs:
           build-args: |
             CMSSPARK_TAG=${{ needs.init-job.outputs.git_tag }}
           tags: registry.cern.ch/cmsmonitoring/cmsmon-rucio-spark2mng:${{ needs.init-job.outputs.git_tag }}, registry.cern.ch/cmsmonitoring/cmsmon-rucio-spark2mng:latest
+
+  build-cmsmon-hdfs:
+    runs-on: ubuntu-latest
+    needs: [ init-job ]
+    if: (needs.init-job.outputs.action == 'all' || contains(needs.init-job.outputs.docker_individual_images, 'cmsmon-hdfs'))
+    name: Build cmsmon-hdfs
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+      - name: Get cmsmon-hdfs Dockerfile
+        run: |
+          curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/cmsmon-hdfs/Dockerfile
+      - name: Login to registry.cern.ch
+        uses: docker/login-action@v1
+        with:
+          registry: registry.cern.ch
+          username: ${{ secrets.CERN_LOGIN }}
+          password: ${{ secrets.CERN_TOKEN }}
+      - name: Publish cmsmon-hdfs image to registry.cern.ch
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          build-args: |
+            CMSSPARK_TAG=${{ needs.init-job.outputs.git_tag }}
+          tags: registry.cern.ch/cmsmonitoring/cmsmon-hdfs:${{ needs.init-job.outputs.git_tag }}, registry.cern.ch/cmsmonitoring/cmsmon-hdfs:latest


### PR DESCRIPTION
[cmsmon-hdfs](https://github.com/dmwm/CMSKubernetes/tree/master/docker/cmsmon-hdfs) will be new base docker image for all spark CronJobs. Eventually, we will use only one docker image. This PR implements its docker build gh action.

@kyrylogy after new tag creation, new image will include bug fix for rucio daily.