### PR TITLE
Update spark 3.2.1 to 3.3.1 requirements and change producer logic that uses StompAMQ7

### DIFF
--- a/bin/cron4crab_popularity.sh
+++ b/bin/cron4crab_popularity.sh
@@ -46,11 +46,11 @@ util_check_and_create_dir "$OUTPUT_DIR"
 util4logi "spark job starting.."
 
 spark_submit_args=(
-    --master yarn --conf spark.ui.showConsoleProgress=false
+    --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC
     --driver-memory=4g --executor-memory=8g --executor-cores=4 --num-executors=30
     --conf "spark.driver.bindAddress=0.0.0.0" --conf "spark.driver.host=${K8SHOST}"
     --conf "spark.driver.port=${PORT1}" --conf "spark.driver.blockManager.port=${PORT2}"
-    --packages org.apache.spark:spark-avro_2.12:3.2.1
+    --packages org.apache.spark:spark-avro_2.12:3.3.1
 )
 
 # run spark function

--- a/bin/cron4crab_popularity.sh
+++ b/bin/cron4crab_popularity.sh
@@ -43,7 +43,7 @@ util4logi "authenticated with Kerberos user: ${KERBEROS_USER}"
 util_check_and_create_dir "$OUTPUT_DIR"
 
 # ----------------------------------------------------------------------------------------------------------------- RUN
-util4logi "spark job starting.."
+util4logi "${myname} Spark Job is starting..."
 
 spark_submit_args=(
     --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC

--- a/bin/cron4crab_unique_users.sh
+++ b/bin/cron4crab_unique_users.sh
@@ -40,7 +40,7 @@ util4logi "authenticated with Kerberos user: ${KERBEROS_USER}"
 util_check_and_create_dir "$OUTPUT_DIR"
 
 # ----------------------------------------------------------------------------------------------------------------- RUN
-util4logi "spark job starting.."
+util4logi "${myname} Spark Job is starting..."
 spark_submit_args=(
     --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC
     --driver-memory=4g --executor-memory=8g --executor-cores=4 --num-executors=30

--- a/bin/cron4crab_unique_users.sh
+++ b/bin/cron4crab_unique_users.sh
@@ -42,11 +42,11 @@ util_check_and_create_dir "$OUTPUT_DIR"
 # ----------------------------------------------------------------------------------------------------------------- RUN
 util4logi "spark job starting.."
 spark_submit_args=(
-    --master yarn --conf spark.ui.showConsoleProgress=false
+    --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC
     --driver-memory=4g --executor-memory=8g --executor-cores=4 --num-executors=30
     --conf "spark.driver.bindAddress=0.0.0.0" --conf "spark.driver.host=${K8SHOST}"
     --conf "spark.driver.port=${PORT1}" --conf "spark.driver.blockManager.port=${PORT2}"
-    --packages org.apache.spark:spark-avro_2.12:3.2.1
+    --packages org.apache.spark:spark-avro_2.12:3.3.1
 )
 # run spark function
 function run_spark() {

--- a/bin/cron4eos_dataset.sh
+++ b/bin/cron4eos_dataset.sh
@@ -43,11 +43,11 @@ util_check_and_create_dir "$OUTPUT_DIR"
 # ----------------------------------------------------------------------------------------------------------------- RUN
 util4logi "spark job starting.."
 spark_submit_args=(
-    --master yarn --conf spark.ui.showConsoleProgress=false
+    --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC
     --driver-memory=4g --executor-memory=8g --executor-cores=4 --num-executors=30
     --conf "spark.driver.bindAddress=0.0.0.0" --conf "spark.driver.host=${K8SHOST}"
     --conf "spark.driver.port=${PORT1}" --conf "spark.driver.blockManager.port=${PORT2}"
-    --packages org.apache.spark:spark-avro_2.12:3.2.1
+    --packages org.apache.spark:spark-avro_2.12:3.3.1
 )
 
 # run spark function

--- a/bin/cron4eos_dataset.sh
+++ b/bin/cron4eos_dataset.sh
@@ -41,7 +41,7 @@ util4logi "authenticated with Kerberos user: ${KERBEROS_USER}"
 util_check_and_create_dir "$OUTPUT_DIR"
 
 # ----------------------------------------------------------------------------------------------------------------- RUN
-util4logi "spark job starting.."
+util4logi "${myname} Spark Job is starting..."
 spark_submit_args=(
     --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC
     --driver-memory=4g --executor-memory=8g --executor-cores=4 --num-executors=30

--- a/bin/cron4gen_crsg_plots.sh
+++ b/bin/cron4gen_crsg_plots.sh
@@ -39,7 +39,7 @@ util4logi "authenticated with Kerberos user: ${KERBEROS_USER}"
 util_check_and_create_dir "$OUTPUT_DIR"
 
 # ----------------------------------------------------------------------------------------------------------- FUNCTIONS
-util4logi "spark job starting.."
+util4logi "${myname} Spark Job is starting..."
 
 spark_submit_args=(
     --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC

--- a/bin/cron4gen_crsg_plots.sh
+++ b/bin/cron4gen_crsg_plots.sh
@@ -42,11 +42,11 @@ util_check_and_create_dir "$OUTPUT_DIR"
 util4logi "spark job starting.."
 
 spark_submit_args=(
-    --master yarn --conf spark.ui.showConsoleProgress=false
+    --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC
     --driver-memory=4g --executor-memory=8g --executor-cores=4 --num-executors=30
     --conf "spark.driver.bindAddress=0.0.0.0" --conf "spark.driver.host=${K8SHOST}"
     --conf "spark.driver.port=${PORT1}" --conf "spark.driver.blockManager.port=${PORT2}"
-    --packages org.apache.spark:spark-avro_2.12:3.2.1
+    --packages org.apache.spark:spark-avro_2.12:3.3.1
 )
 
 # run spark function

--- a/bin/cron4hpc_at_cms.sh
+++ b/bin/cron4hpc_at_cms.sh
@@ -38,7 +38,7 @@ util4logi "authenticated with Kerberos user: ${KERBEROS_USER}"
 util_check_and_create_dir "$OUTPUT_DIR"
 
 # ----------------------------------------------------------------------------------------------------------------- RUN
-util4logi "spark job starting.."
+util4logi "${myname} Spark Job is starting..."
 spark_submit_args=(
     --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC
     --driver-memory=4g --executor-memory=8g --executor-cores=4 --num-executors=30

--- a/bin/cron4hpc_at_cms.sh
+++ b/bin/cron4hpc_at_cms.sh
@@ -40,11 +40,11 @@ util_check_and_create_dir "$OUTPUT_DIR"
 # ----------------------------------------------------------------------------------------------------------------- RUN
 util4logi "spark job starting.."
 spark_submit_args=(
-    --master yarn --conf spark.ui.showConsoleProgress=false
+    --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC
     --driver-memory=4g --executor-memory=8g --executor-cores=4 --num-executors=30
     --conf "spark.driver.bindAddress=0.0.0.0" --conf "spark.driver.host=${K8SHOST}"
     --conf "spark.driver.port=${PORT1}" --conf "spark.driver.blockManager.port=${PORT2}"
-    --packages org.apache.spark:spark-avro_2.12:3.2.1
+    --packages org.apache.spark:spark-avro_2.12:3.3.1
 )
 
 # run spark function

--- a/bin/cron4hpc_usage.sh
+++ b/bin/cron4hpc_usage.sh
@@ -89,7 +89,7 @@ util4logi "spark job starting.."
 spark_submit_args=(
     --master yarn --conf spark.ui.showConsoleProgress=false --conf "spark.driver.bindAddress=0.0.0.0" --driver-memory=8g --executor-memory=8g
     --conf "spark.driver.host=${K8SHOST}" --conf "spark.driver.port=${PORT1}" --conf "spark.driver.blockManager.port=${PORT2}"
-    --packages org.apache.spark:spark-avro_2.12:3.2.1 --conf spark.sql.session.timeZone=UTC
+    --packages org.apache.spark:spark-avro_2.12:3.3.1 --conf spark.sql.session.timeZone=UTC
 )
 
 py_input_args=(--output_dir "$OUTPUT_DIR" --url_prefix "$URL_PREFIX" --html_template "$HTML_TEMPLATE")

--- a/bin/cron4hs06_cputime_plot.sh
+++ b/bin/cron4hs06_cputime_plot.sh
@@ -43,11 +43,11 @@ util_check_and_create_dir "$OUTPUT_DIR"
 util4logi "spark job starting.."
 
 spark_submit_args=(
-    --master yarn --conf spark.ui.showConsoleProgress=false
+    --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC
     --driver-memory=4g --executor-memory=8g --executor-cores=4 --num-executors=30
     --conf "spark.driver.bindAddress=0.0.0.0" --conf "spark.driver.host=${K8SHOST}"
     --conf "spark.driver.port=${PORT1}" --conf "spark.driver.blockManager.port=${PORT2}"
-    --packages org.apache.spark:spark-avro_2.12:3.2.1
+    --packages org.apache.spark:spark-avro_2.12:3.3.1
 )
 
 # run spark function

--- a/bin/cron4hs06_cputime_plot.sh
+++ b/bin/cron4hs06_cputime_plot.sh
@@ -40,7 +40,7 @@ util4logi "authenticated with Kerberos user: ${KERBEROS_USER}"
 util_check_and_create_dir "$OUTPUT_DIR"
 
 # ----------------------------------------------------------------------------------------------------------------- RUN
-util4logi "spark job starting.."
+util4logi "${myname} Spark Job is starting..."
 
 spark_submit_args=(
     --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC

--- a/bin/cron4rucio_daily.sh
+++ b/bin/cron4rucio_daily.sh
@@ -66,7 +66,7 @@ util4logi "spark job starting.."
 spark_submit_args=(
     --master yarn --conf spark.ui.showConsoleProgress=false --conf "spark.driver.bindAddress=0.0.0.0" --driver-memory=8g --executor-memory=8g
     --conf "spark.driver.host=${K8SHOST}" --conf "spark.driver.port=${PORT1}" --conf "spark.driver.blockManager.port=${PORT2}"
-    --packages org.apache.spark:spark-avro_2.12:3.2.1
+    --packages org.apache.spark:spark-avro_2.12:3.3.1
 )
 py_input_args=(--verbose --output "$OUTPUT_DIR" --fdate "$current_date")
 

--- a/bin/cron4rucio_datasets_daily_stats.sh
+++ b/bin/cron4rucio_datasets_daily_stats.sh
@@ -179,11 +179,11 @@ util4logi "dumps are finished. Time spent: $(util_secs_to_human "$(($(date +%s) 
 util4logi "spark job starts"
 export PYTHONPATH=$script_dir/../src/python:$PYTHONPATH
 spark_submit_args=(
-    --master yarn --conf spark.ui.showConsoleProgress=false
-    --driver-memory=4g --executor-memory=8g --executor-cores=4 --num-executors=30
+    --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC
+    --driver-memory=8g --executor-memory=8g --executor-cores=4 --num-executors=30
     --conf "spark.driver.bindAddress=0.0.0.0" --conf "spark.driver.host=${K8SHOST}"
     --conf "spark.driver.port=${PORT1}" --conf "spark.driver.blockManager.port=${PORT2}"
-    --packages org.apache.spark:spark-avro_2.12:3.2.1 --py-files "${CMSMONITORING_ZIP},${STOMP_ZIP}"
+    --packages org.apache.spark:spark-avro_2.12:3.3.1 --py-files "${CMSMONITORING_ZIP},${STOMP_ZIP}"
 )
 py_input_args=(
     --creds "$AMQ_JSON_CREDS"

--- a/bin/cron4rucio_datasets_daily_stats.sh
+++ b/bin/cron4rucio_datasets_daily_stats.sh
@@ -176,7 +176,7 @@ util4logi "dumps are finished. Time spent: $(util_secs_to_human "$(($(date +%s) 
 
 # ------------------------------------------------------------------------------------------------------- RUN SPARK JOB
 # Required for Spark job in K8s
-util4logi "spark job starts"
+util4logi "${myname} Spark Job is starting..."
 export PYTHONPATH=$script_dir/../src/python:$PYTHONPATH
 spark_submit_args=(
     --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC

--- a/bin/cron4rucio_datasets_last_access_ts.sh
+++ b/bin/cron4rucio_datasets_last_access_ts.sh
@@ -81,6 +81,7 @@ main() {
         --conf spark.executor.cores=4
         --conf spark.driver.memory=4g
         --conf spark.ui.showConsoleProgress=false
+        --conf spark.sql.session.timeZone=UTC
         --packages org.apache.spark:spark-avro_2.11:2.4.3
     )
 

--- a/bin/cron4rucio_datasets_to_mongo.sh
+++ b/bin/cron4rucio_datasets_to_mongo.sh
@@ -116,7 +116,7 @@ function run_spark_and_mongo_import() {
     export PYTHONPATH=$script_dir/../src/python:$PYTHONPATH
     spark_submit_args=(
         --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC --conf "spark.driver.bindAddress=0.0.0.0"
-        --driver-memory=8g --executor-memory=8g --packages org.apache.spark:spark-avro_2.12:3.2.1
+        --driver-memory=8g --executor-memory=8g --packages org.apache.spark:spark-avro_2.12:3.3.1
         --conf "spark.driver.host=${K8SHOST}" --conf "spark.driver.port=${PORT1}" --conf "spark.driver.blockManager.port=${PORT2}"
     )
     py_input_args=(--hdfs_out_dir "$hdfs_out_dir")

--- a/bin/cron4rucio_ds_summary.sh
+++ b/bin/cron4rucio_ds_summary.sh
@@ -89,7 +89,7 @@ export PYTHONPATH=$script_dir/../src/python:$PYTHONPATH
 spark_submit_args=(
     --master yarn --conf spark.ui.showConsoleProgress=false --conf "spark.driver.bindAddress=0.0.0.0" --driver-memory=8g --executor-memory=8g
     --conf "spark.driver.host=${K8SHOST}" --conf "spark.driver.port=${PORT1}" --conf "spark.driver.blockManager.port=${PORT2}"
-    --packages org.apache.spark:spark-avro_2.12:3.2.1 --py-files "${CMSMONITORING_ZIP},${STOMP_ZIP}"
+    --packages org.apache.spark:spark-avro_2.12:3.3.1 --py-files "${CMSMONITORING_ZIP},${STOMP_ZIP}"
 )
 py_input_args=(--creds "$AMQ_JSON_CREDS" --amq_batch_size 1000)
 function run_spark() {

--- a/bin/cron4rucio_ds_summary.sh
+++ b/bin/cron4rucio_ds_summary.sh
@@ -84,7 +84,7 @@ util4logi "authenticated with ${KERBEROS_USER} user's keytab"
 
 # ------------------------------------------------------------------------------------------------------- RUN SPARK JOB
 # Required for Spark job in K8s
-util4logi "spark job starts"
+util4logi "cron4rucio_ds_summary Spark Job is starting..."
 export PYTHONPATH=$script_dir/../src/python:$PYTHONPATH
 spark_submit_args=(
     --master yarn --conf spark.ui.showConsoleProgress=false --conf "spark.driver.bindAddress=0.0.0.0" --driver-memory=8g --executor-memory=8g

--- a/bin/k8s_condor_cpu_efficiency.sh
+++ b/bin/k8s_condor_cpu_efficiency.sh
@@ -59,7 +59,7 @@ CPU_EFF_OUTLIER_DIR="${CPU_EFF_DIR}_outlier"
 CMS_TYPES=("analysis" "production" "folding@home" "test")
 
 # ---------------------------------------------------------------------------------------------------------------------
-util4logi "Condor cpu efficiency starts"
+util4logi "${myname} Spark Job is starting..."
 for type in "${CMS_TYPES[@]}"; do
     SUB_FOLDER=$(echo "$type" | sed -e 's/[^[:alnum:]]/-/g' | tr -s '-' | tr '[:upper:]' '[:lower:]')
 

--- a/bin/k8s_condor_cpu_efficiency.sh
+++ b/bin/k8s_condor_cpu_efficiency.sh
@@ -45,7 +45,7 @@ mkdir -p "$LOG_DIR"
 
 # ----------------------------------------------------------------------------------------------------------------- RUN
 spark_confs=(
-    --master yarn --conf spark.ui.showConsoleProgress=false
+    --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC
     --driver-memory=4g --executor-memory=8g --executor-cores=4 --num-executors=30
     --conf "spark.driver.bindAddress=0.0.0.0" --conf "spark.driver.host=${K8SHOST}"
     --conf "spark.driver.port=${PORT1}" --conf "spark.driver.blockManager.port=${PORT2}"

--- a/bin/k8s_stepchain_cpu_eff.sh
+++ b/bin/k8s_stepchain_cpu_eff.sh
@@ -43,7 +43,7 @@ LOG_DIR="$WDIR"/logs/$(date +%Y%m%d)
 mkdir -p "$LOG_DIR"
 # ----------------------------------------------------------------------------------------------------------------- RUN
 spark_confs=(
-    --master yarn --conf spark.ui.showConsoleProgress=false
+    --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC
     --driver-memory=8g --executor-memory=8g --executor-cores=4 --num-executors=30
     --conf "spark.driver.bindAddress=0.0.0.0" --conf "spark.driver.host=${K8SHOST}"
     --conf "spark.driver.port=${PORT1}" --conf "spark.driver.blockManager.port=${PORT2}"

--- a/bin/run_spark3.sh
+++ b/bin/run_spark3.sh
@@ -96,7 +96,7 @@ fi
 conf+=(
     --master yarn
     --conf spark.executor.memory=5g --conf spark.driver.memory=4g
-    --packages org.apache.spark:spark-avro_2.12:3.2.1
+    --packages org.apache.spark:spark-avro_2.12:3.3.1
 )
 
 util4logi "PYTHONPATH: $PYTHONPATH"

--- a/bin/utils/common_utils.sh
+++ b/bin/utils/common_utils.sh
@@ -194,6 +194,9 @@ function util_setup_spark_k8s() {
     source hadoop-setconf.sh analytix 3.2 spark3
     export SPARK_LOCAL_IP=127.0.0.1
     export PYSPARK_PYTHON=/cvmfs/sft.cern.ch/lcg/releases/Python/3.9.6-b0f98/x86_64-centos7-gcc8-opt/bin/python3
+    # until IT changes this setting, we need to turn off info logs in this way. Don't try spark.sparkContext.setLogLevel('WARN'), doesn't work, since they are not spark logs but spark-submit logs.
+    sed -i 's/rootLogger.level = info/rootLogger.level = warn/g' $SPARK_CONF_DIR/log4j2.properties
+
 }
 
 #######################################

--- a/doc/pyspark_shell.md
+++ b/doc/pyspark_shell.md
@@ -26,7 +26,7 @@ spark_submit_args=(
   --master yarn 
   --conf spark.ui.showConsoleProgress=false 
   --driver-memory=8g --executor-memory=8g
-  --packages org.apache.spark:spark-avro_2.12:3.2.1 
+  --packages org.apache.spark:spark-avro_2.12:3.3.1 
   --py-files "/data/CMSMonitoring.zip,/data/stomp-v700.zip"
 )
 
@@ -63,7 +63,7 @@ spark_submit_args=(
   --conf "spark.driver.host=${MY_NODE_NAME}" 
   --conf "spark.driver.port=31201" 
   --conf "spark.driver.blockManager.port=31202"
-  --packages org.apache.spark:spark-avro_2.12:3.2.1 
+  --packages org.apache.spark:spark-avro_2.12:3.3.1 
   --py-files "/data/CMSMonitoring.zip,/data/stomp-v700.zip"
 )
 

--- a/src/python/CMSSpark/rucio_ds_summary.py
+++ b/src/python/CMSSpark/rucio_ds_summary.py
@@ -370,12 +370,12 @@ def send_to_amq(data, confs, batch_size):
         port = int(confs.get('port'))
         cert = confs.get('cert', None)
         ckey = confs.get('ckey', None)
-        stomp_amq = StompAMQ7(username=username, password=password, producer=producer, topic=topic,
-                              key=ckey, cert=cert, validation_schema=None, host_and_ports=[(host, port)],
-                              loglevel=logging.WARNING)
         # Slow: stomp_amq.send_as_tx(chunk, docType=doc_type)
         #
         for chunk in to_chunks(data, batch_size):
+            stomp_amq = StompAMQ7(username=username, password=password, producer=producer, topic=topic,
+                                  key=ckey, cert=cert, validation_schema=None, host_and_ports=[(host, port)],
+                                  loglevel=logging.WARNING)
             messages = []
             for msg in chunk:
                 notif, _, _ = stomp_amq.make_notification(payload=msg, doc_type=doc_type, producer=producer)


### PR DESCRIPTION
- Updates requirements(avro version) of spark3.2 to spark3.3 which is the latest spark release of CERN
- New updates come with new issues. Default `rootLogger.level = info` setting produce lots of info logs. It is replaced with `warn` in util function using sed.
- Stepchain cpu efficiency job should use 8g driver memory for now.
- Latest fix in StompAMQ7 module of CMSMonitoring forces to close AMQ connection after send. Previous logic was causing connection lost, it is fixed.