### PR TITLE
Create OpenSearch client and WMArchive agent job count per hour

### DIFF
--- a/bin/cron4wma_agent_count.sh
+++ b/bin/cron4wma_agent_count.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# shellcheck disable=SC2068
+set -e
+##H cron4wma_agent_count.sh
+##H    Weekly cron job of wma_agent_count_to_opensearch.py
+##H    This cron job calculates daily agent count per host and send to OpenSearch es-cms test tenant WEEKLY
+##H
+##H Example: cron4wma_agent_count.sh --keytab ./keytab --conf ./secret_opensearch.txt --p1 32000 --p2 32001 --host $MY_NODE_NAME --wdir $WDIR
+##H Arguments:
+##H   - keytab             : Kerberos auth file: secrets/keytab
+##H   - conf               : OpenSearch secret file in format of only one line "username:password"
+##H   - p1, p2, host, wdir : [ALL FOR K8S] p1 and p2 spark required ports(driver and blockManager), host is k8s node dns alias, wdir is working directory
+##H How to test: Just send data to different index.
+##H
+TZ=UTC
+START_TIME=$(date +%s)
+myname=$(basename "$0")
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+. "$script_dir"/utils/common_utils.sh
+
+if [ "$1" == "" ] || [ "$1" == "-h" ] || [ "$1" == "--help" ] || [ "$1" == "-help" ]; then
+    util_usage_help
+    exit 0
+fi
+# weekly: 1w
+util_cron_send_start "$myname" "1w"
+export PYTHONPATH=$script_dir/../src/python:$PYTHONPATH
+
+unset -v KEYTAB_SECRET CONF_FILE PORT1 PORT2 K8SHOST WDIR IS_TEST
+# ------------------------------------------------------------------------------------------------------------- PREPARE
+util_input_args_parser $@
+
+util4logi "Parameters: KEYTAB_SECRET:${KEYTAB_SECRET} CONF_FILE:${CONF_FILE} PORT1:${PORT1} PORT2:${PORT2} K8SHOST:${K8SHOST} WDIR:${WDIR} IS_TEST:${IS_TEST}"
+util_check_vars KEYTAB_SECRET CONF_FILE PORT1 PORT2 K8SHOST WDIR
+util_setup_spark_k8s
+
+KERBEROS_USER=$(util_kerberos_auth_with_keytab "$KEYTAB_SECRET")
+util4logi "authenticated with Kerberos user: ${KERBEROS_USER}"
+
+# ----------------------------------------------------------------------------------------------------------------- RUN
+spark_submit_args=(
+    --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC
+    --conf "spark.driver.bindAddress=0.0.0.0" --conf "spark.driver.host=${K8SHOST}"
+    --conf "spark.driver.port=${PORT1}" --conf "spark.driver.blockManager.port=${PORT2}"
+    --driver-memory=8g --executor-memory=8g --packages org.apache.spark:spark-avro_2.12:3.4.0
+)
+# -------------------------------------------------------------------------------------------------------------- PARAMS
+# 3 days of buffer time for WMArchive HDFS data. Because we'll run WEEKLY: 10 days - 3 days = 7 days = 1 week
+_start_date=$(date -d "10 days ago" +%Y-%m-%d)
+_end_date=$(date -d "3 days ago" +%Y-%m-%d)
+ES_INDEX="test-wmarchive-agent-count"
+ES_HOST="es-cms1.cern.ch/es"
+
+util4logi "${myname} Spark Job is starting... between input dates of ${_start_date} - ${_end_date}"
+# ---------------------------------------------------------------------------------------------------------------------
+
+py_input_args=(--start_date "$_start_date" --end_date "$_end_date" --es_host "$ES_HOST" --es_index "$ES_INDEX" --es_secret_file "$CONF_FILE")
+
+# Run
+spark-submit "${spark_submit_args[@]}" "$script_dir/../src/python/CMSSpark/wma_agent_count_to_opensearch.py" "${py_input_args[@]}" 2>&1
+
+duration=$(($(date +%s) - START_TIME))
+util_cron_send_end "$myname" "1w" 0
+util4logi "all finished, time spent: $(util_secs_to_human $duration)"

--- a/src/python/CMSSpark/osearch/README.md
+++ b/src/python/CMSSpark/osearch/README.md
@@ -1,0 +1,79 @@
+## OpenSearch Client to send data
+
+Requirements:
+
+- opensearch-py~=2.1
+- OpenSearch cluster host name.
+- Secret file one line of 'username:password' of the OpenSearch. Ask to CMS Monitoring team.
+- Index mapping schema and settings, see get_index_schema() below.
+- Index template starting with 'test-' if you want to send to es-cms cluster "test" tenant
+- `index_mod`: Let's assume you've an index_template of "test-foo". Depending on your input and provided timestamp, data
+  will be sent to below indexes:
+    - index_mod="": `test-foo`
+    - index_mod="Y": `test-foo-YYYY`
+    - index_mod="M": `test-foo-YYYY-MM`
+    - index_mod="D": `test-foo-YYYY-MM-DD`
+
+## How to use
+
+##### Simple detailed
+
+```python
+
+import time
+from CMSSpark.osearch import osearch
+
+# Example documents to send
+docs = [{"timestamp": "int epoch_seconds", "field1": "t1 short", "field2": "t2 long text", "count": 1}, {...}, {...},
+        ...]
+
+
+# Define your index mapping and settings:
+def get_index_schema():
+    return {
+        "settings": {"index": {"number_of_shards": "1", "number_of_replicas": "1"}},
+        "mappings": {
+            "properties": {
+                "timestamp": {"format": "epoch_second", "type": "date"},
+                "field1": {"ignore_above": 1024, "type": "keyword"},
+                "field2": {"type": "text"},
+                "count": {"type": "long"},
+            }
+        }
+    }
+
+
+_index_template = 'test-foo'
+client = osearch.get_es_client("es-cms1.cern.ch/es", 'secret_opensearch.txt', get_index_schema())
+
+# index_mod="": 'test-foo', index_mod="Y": 'test-foo-YYYY', index_mod="M": 'test-foo-YYYY-MM', index_mod="D": 'test-foo-YYYY-MM-DD',
+idx = client.get_or_create_index(timestamp=time.time(), index_template=_index_template, index_mod="")
+
+client.send(idx, docs, metadata=None, batch_size=10000, drop_nulls=False)
+```
+
+##### Big Spark dataframe to OpenSearch, efficiently
+
+If you're wondering how to send very big data of PySpark dataframe, here is a tip.
+
+```python
+# See "get_index_schema()" example from previous example.
+# See "index_mod" explanation in the "Requirements" part.
+
+from CMSSpark.osearch import osearch
+
+for part in df.rdd.mapPartitions().toLocalIterator():
+    # You can define below calls in a function for re-usability
+    _index_template = 'test-foo'
+    client = osearch.get_es_client("es-cms1.cern.ch/es", 'secret_opensearch.txt', get_index_schema())
+    print(f"Length of partition: {len(part)}")
+    idx = client.get_or_create_index(timestamp=part[0]['timestamp'], index_template=_index_template,
+                                     index_mod="D")  # sends to daily index
+    client.send(idx, part, metadata=None, batch_size=10000, drop_nulls=False)
+```
+
+##### Small Spark dataframe
+
+Go with the first example to send:
+
+`docs = df.toPandas().to_dict('records') # and go with 'Simple detailed` example`

--- a/src/python/CMSSpark/osearch/osearch.py
+++ b/src/python/CMSSpark/osearch/osearch.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+File        : osearch.py
+Author      : Ceyhun Uzunoglu <ceyhunuzngl AT gmail [DOT] com>
+Description : OpenSearch client to send data to CERN IT OpenSearch clusters
+
+Requirements:
+    - opensearch-py~=2.1
+    - OpenSearch cluster host name.
+    - Secret file one line of 'username:password' of the OpenSearch. Ask to CMS Monitoring team.
+    - Index mapping schema and settings, see get_index_schema() below.
+    - Index template starting with 'test-'.
+
+How to use:
+    # ------------------------------- Simple detailed -------------------------------------
+    # Example documents to send
+    docs = [{"timestamp": epoch_seconds, "field1": "t1 short", "field2": "t2 long text", "count": 1}, {...}, {...}, ...]
+
+    # Define your index mapping and settings:
+    def get_index_schema():
+        return {
+            "settings": {"index": {"number_of_shards": "1", "number_of_replicas": "1"}},
+            "mappings": {
+                "properties": {
+                    "timestamp": {"format": "epoch_second", "type": "date"},
+                    "field1": {"ignore_above": 1024, "type": "keyword"},
+                    "field2": {"type": "text"},
+                    "count": {"type": "long"},
+                }
+            }
+        }
+
+    _index_template = 'test-foo'
+    client = osearch.get_es_client("es-cms1.cern.ch/es", 'secret_opensearch.txt', get_index_schema())
+
+    # index_mod="": 'test-foo', index_mod="Y": 'test-foo-YYYY', index_mod="M": 'test-foo-YYYY-MM', index_mod="D": 'test-foo-YYYY-MM-DD',
+    idx = client.get_or_create_index(timestamp=time.time(), index_template=_index_template, index_mod="")
+
+    client.send(idx, docs, metadata=None, batch_size=10000, drop_nulls=False)
+
+    # ------------------------------- Big Spark dataframe -------------------------------------
+    _index_template = 'test-foo'
+    client = osearch.get_es_client("es-cms1.cern.ch/es", 'secret_opensearch.txt', get_index_schema())
+    for part in df.rdd.mapPartitions().toLocalIterator():
+        print(f"Length of partition: {len(part)}")
+        # You can define below calls in a function for reusability
+        idx = client.get_or_create_index(timestamp=part[0]['timestamp'], index_template=_index_template, index_mod="D") # sends to daily index
+        client.send(idx, part, metadata=None, batch_size=10000, drop_nulls=False)
+
+    # ------------------------------- Small Spark dataframe -------------------------------------
+    docs = df.toPandas().to_dict('records') # and go with 'Simple detailed` example
+"""
+
+import json
+import logging
+import time
+from collections import Counter as collectionsCounter
+from datetime import datetime
+
+from opensearchpy import OpenSearch
+
+# Global OpenSearch connection client
+_opensearch_client = None
+
+# Global index cache, keep tracks of indices that are already created with mapping in the OpenSearch instance
+_index_cache = set()
+
+
+def get_es_client(host, secret_file, index_mapping_and_settings):
+    """Creates OpenSearch client
+
+    Uses a global OpenSearch client and return it if connection still holds, otherwise creates a new connection.
+    """
+    global _opensearch_client
+    if not _opensearch_client:
+        # reinitialize
+        _opensearch_client = OpenSearchInterface(host, secret_file, index_mapping_and_settings)
+    return _opensearch_client
+
+
+class OpenSearchInterface(object):
+    """Robust interface to OpenSearch cluster
+
+    secret_es.txt: "username:password"
+    """
+
+    def __init__(self, host, secret_file, index_mapping_and_settings):
+        try:
+            logging.info("OpenSearch instance is initializing")
+            self.host = host
+            self.secret_file = secret_file
+            self.index_mapping_and_settings = index_mapping_and_settings
+            username, password = open(secret_file).readline().split(':')
+            username, password = username.strip(), password.strip()
+            url = 'https://' + username + ':' + password + '@' + host
+            self.handle = OpenSearch(
+                [url],
+                verify_certs=True,
+                use_ssl=True,
+                ca_certs='/etc/pki/tls/certs/ca-bundle.trust.crt',
+            )
+        except Exception as e:
+            logging.error("OpenSearchInterface initialization failed: " + str(e))
+
+    def make_mapping(self, idx):
+        """Creates mapping of the index
+
+        idx: Full index name test-foo(no date format), test-foo-YYYY-MM-DD(index_mod=D)
+        """
+        body = json.dumps(self.index_mapping_and_settings)
+        # Make mappings for OpenSearch index
+        result = self.handle.indices.create(index=idx, body=body, ignore=400)
+        if result.get("status") != 400:
+            logging.warning("Creation of index %s: %s" % (idx, str(result)))
+        elif "already exists" not in result.get("error", "").get("reason", ""):
+            logging.error("Creation of index %s failed: %s" % (idx, str(result.get("error", ""))))
+
+    def get_or_create_index(self, timestamp, index_template, index_mod=""):
+        """Creates index with mappings and settings if not exist
+
+
+        timestamp      : epoch seconds
+        index_template : index base name
+        index_mode     : one of 'Y': "index_template"-YYYY, 'M': "index_template"-YYYY-MM, 'D': "index_template"-YYYY-MM-DD,
+                           empty string uses single index as "index_template"
+
+        Returns yearly/monthly/daily index string depending on the index_mode and creates it if it does not exist.
+        - It checks if index mapping is already created by checking _index_cache set.
+        - And returns from _index_cache set if index exists
+        - Else, it creates the index with mapping which happens in the first batch of the month ideally.
+        """
+        global _index_cache
+
+        timestamp = int(timestamp)
+        if index_mod.upper() == "Y":
+            idx = time.strftime("%s-%%Y" % index_template, datetime.utcfromtimestamp(timestamp).timetuple())
+        elif index_mod.upper() == "M":
+            idx = time.strftime("%s-%%Y-%%m" % index_template, datetime.utcfromtimestamp(timestamp).timetuple())
+        elif index_mod.upper() == "D":
+            idx = time.strftime("%s-%%Y-%%m-%%d" % index_template, datetime.utcfromtimestamp(timestamp).timetuple())
+        else:
+            idx = index_template
+
+        if idx in _index_cache:
+            return idx
+        get_es_client(self.host, self.secret_file, self.index_mapping_and_settings).make_mapping(idx=idx)
+        _index_cache.add(idx)
+        return idx
+
+    @staticmethod
+    def parse_errors(result):
+        """Parses bulk send result and finds errors to log
+        """
+        reasons = [d.get("index", {}).get("error", {}).get("reason", None) for d in result["items"]]
+        counts = collectionsCounter([_f for _f in reasons if _f])
+        n_failed = sum(counts.values())
+        logging.error("Failed to index %d documents to OpenSearch: %s" % (n_failed, str(counts.most_common(3))))
+        return n_failed
+
+    @staticmethod
+    def drop_nulls_in_dict(d):  # d: dict
+        """Drops the dict key if the value is None
+
+        OpenSearch mapping does not allow None values and drops the document completely.
+        """
+        return {k: v for k, v in d.items() if v is not None}  # dict
+
+    @staticmethod
+    def to_chunks(data, samples=10000):
+        """Yields chunks of data"""
+        length = len(data)
+        for i in range(0, length, samples):
+            yield data[i:i + samples]
+
+    @staticmethod
+    def make_es_body(bulk_list, metadata=None):
+        """Prepares documents for bulk send by adding metadata part and separating with new line
+        """
+        metadata = metadata or {}
+        body = ""
+        for data in bulk_list:
+            if metadata:
+                data.setdefault("metadata", {}).update(metadata)
+            body += json.dumps({"index": {}}) + "\n"
+            body += json.dumps(data) + "\n"
+        return body
+
+    def send(self, idx, data, metadata=None, batch_size=10000, drop_nulls=False):
+        """Send data in bulks to OpenSearch instance, batching is implemented by default.
+
+        Args:
+            idx: full index name, can be index_template or index_template-YYYY-..
+            data: can be a single document or list of documents to send
+            metadata: metadata that will be sent with each document
+            batch_size: batching sample size
+            drop_nulls: in Grafana, null strings cause trouble in aggregations. If it is true, it drops None fields from the documents.
+        """
+        global _opensearch_client
+        _opensearch_client = get_es_client(self.host, self.secret_file, self.index_mapping_and_settings)
+
+        # If one document as dict, make it list
+        if not isinstance(data, list):
+            data = [data]
+
+        result_n_failed = 0
+        for chunk in self.to_chunks(data, batch_size):
+            if drop_nulls:
+                chunk = [self.drop_nulls_in_dict(_x) for _x in chunk]
+            body = self.make_es_body(chunk, metadata)
+            res = _opensearch_client.handle.bulk(body=body, index=idx, request_timeout=300)
+            if res.get("errors"):
+                result_n_failed += self.parse_errors(res)
+        if result_n_failed > 0:
+            logging.error("OpenSearch send failed count: ", result_n_failed)
+        logging.debug("OpenSearch send", len(data) - result_n_failed, "documents successfully")
+        return result_n_failed

--- a/src/python/CMSSpark/wma_agent_count_to_opensearch.py
+++ b/src/python/CMSSpark/wma_agent_count_to_opensearch.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+File        : wma_agent_count_to_opensearch.py
+Author      : Ceyhun Uzunoglu <ceyhunuzngl AT gmail [DOT] com>
+Description : Sends historical hourly aggregated WMArchive data to es-cms test tenant for debugging purpose
+              Hourly aggregated agent count per host with following fields:
+              "wmats_midday": aggregation is daily, so we use midday timestamp of wmats
+              "day": string yyyy-mm-dd
+              "host": WMA agent
+              "count": count of "['day', 'host']" aggregation, number of wmarchive input(job) per host per day
+              "avg_steps_count": average step cont for that day for the agent
+              "sites": collected set of sites that host reported
+
+Requirements:
+    - opensearch-py~=2.1
+    - SWAN: !pip install --user opensearch-py~=2.1
+"""
+import time
+from datetime import timezone
+
+import click as click
+import pandas as pd
+from pyspark.sql.functions import (
+    avg as _avg, col, collect_set as _collect_set, count as _count, first as _first, from_unixtime, lit,
+)
+from pyspark.sql.types import StructType, StructField, StringType, IntegerType, LongType
+
+from CMSSpark.osearch import osearch
+from CMSSpark.spark_utils import get_spark_session, get_candidate_files
+
+pd.options.display.float_format = "{:,.2f}".format
+pd.set_option("display.max_colwidth", None)
+
+# global variables
+_DEFAULT_HDFS_FOLDER = "/project/monitoring/archive/wmarchive/raw/metric"
+_VALID_DATE_FORMATS = ["%Y/%m/%d", "%Y-%m-%d", "%Y%m%d"]
+
+
+def get_rdd_schema():
+    """Final schema of steps"""
+    return StructType(
+        [
+            StructField('ts', LongType(), nullable=False),
+            StructField('wmats', LongType(), nullable=False),
+            StructField('site', StringType(), nullable=True),
+            StructField('host', StringType(), nullable=False),
+            StructField('number_of_steps', IntegerType(), nullable=False),
+            StructField('wmaid', StringType(), nullable=False),
+        ]
+    )
+
+
+def udf_step_extract(row):
+    """
+    Borrowed from wmarchive.py
+
+    Helper function to extract useful data from WMArchive records. Returns list of step_res
+    """
+    wmaid, wmats, host, ts = row['wmaid'], row['wmats'], row['meta_data']['host'], row['meta_data']['ts']
+    site_name, count = "UNKNOWN", 0
+
+    result = {'host': host, 'ts': ts, 'wmaid': wmaid, 'wmats': wmats}
+    if 'steps' in row:
+        for step in row['steps']:
+            count += 1
+            if step['site'] is not None:
+                site_name = step['site']
+    result['site'] = site_name
+    result['number_of_steps'] = count
+    return [result]
+
+
+def get_index_schema():
+    """
+    Creates mapping dictionary for the unified-logs monthly index
+    """
+    # !PLEASE! Modify # of shards and replicas according to your data size.
+    #             For 30GB, 1 shard 1 replica can be enough.
+    return {
+        "settings": {"index": {"number_of_shards": "2", "number_of_replicas": "1"}},
+        "mappings": {
+            "properties": {
+                "wmats_midday": {"format": "epoch_second", "type": "date"},
+                "day": {"ignore_above": 32, "type": "keyword"},
+                "host": {"ignore_above": 256, "type": "keyword"},
+                "count": {"type": "long"},
+                "avg_steps_count": {"type": "long"},
+                "sites": {"type": "text"},
+            }
+        }
+    }
+
+
+def drop_nulls_in_dict(d):  # d: dict
+    """Drops the dict key if the value is None
+
+    ES mapping does not allow None values and drops the document completely.
+    """
+    return {k: v for k, v in d.items() if v is not None}  # dict
+
+
+def send(part, opensearch_host, es_secret_file, es_index_template):
+    """Send given data to OpenSearch"""
+    client = osearch.get_es_client(opensearch_host, es_secret_file, get_index_schema())
+    # Monthly index format: index_mod="M"
+    idx = client.get_or_create_index(timestamp=time.time(), index_template=es_index_template, index_mod="M")
+    client.send(idx, part, metadata=None, batch_size=10000, drop_nulls=False)
+
+
+@click.command()
+@click.option("--start_date", required=False, type=click.DateTime(_VALID_DATE_FORMATS))
+@click.option("--end_date", required=False, type=click.DateTime(_VALID_DATE_FORMATS))
+@click.option('--es_host', required=True, default=None, type=str,
+              help='OpenSearch host name without port: es-cms1.cern.ch/es')
+@click.option('--es_secret_file', required=True, default=None, type=str,
+              help='OpenSearch secret file that contains "user:pass" only')
+@click.option('--es_index', required=True, default=None, type=str,
+              help='OpenSearch index template (prefix), i.e.: "test-wmarchive-agent-count"')
+def main(start_date, end_date, es_host, es_secret_file, es_index):
+    click.echo(f'input args: start_date:{start_date}, end_date:{end_date}, es_host:{es_host}, es_index:{es_index}')
+    spark = get_spark_session(app_name='cmsmonit-wma-agent-count')
+    start_date = start_date.replace(tzinfo=timezone.utc)
+    end_date = end_date.replace(tzinfo=timezone.utc)
+    spark.conf.set("spark.sql.session.timeZone", "UTC")
+
+    df_raw = (
+        spark.read.option("basePath", _DEFAULT_HDFS_FOLDER).json(
+            get_candidate_files(start_date, end_date, spark, base=_DEFAULT_HDFS_FOLDER, day_delta=2)
+        )
+        .select(["data.*", "metadata.timestamp"])
+        .filter(f"""data.wmats >= {start_date.timestamp()} AND data.wmats < {end_date.timestamp()} """)
+    )
+
+    df_rdd = df_raw.rdd.flatMap(lambda r: udf_step_extract(r))
+    df = spark.createDataFrame(df_rdd, schema=get_rdd_schema()).dropDuplicates(['wmaid'])
+    df = df.withColumn('day', from_unixtime(col('wmats'), 'yyyy-MM-dd'))
+    df = df.groupby(['day', 'host']).agg(
+        _count(lit(1)).alias('count'),  # no duplicate wmaid
+        _avg(col('number_of_steps')).alias('avg_steps_count'),
+        _collect_set(col('site')).alias('sites'),
+        (_first(col('wmats')) - (_first(col('wmats')) % 86400) + 43200).alias('wmats_midday')
+    )
+    for part in df.rdd.mapPartitions(lambda p: [[drop_nulls_in_dict(x.asDict()) for x in p]]).toLocalIterator():
+        part_size = len(part)
+        print(f"Length of partition: {part_size}")
+        send(part, opensearch_host=es_host, es_secret_file=es_secret_file, es_index_template=es_index)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
New Python module **osearch** to send data to OpenSearch `from CMSSpark import osearch`: `CMSSpark/src/python/CMSSpark/osearch`
- Please see its README.md for its usage
- It can be safely used in PySpark jobs

New weekly cron job in K8s: `cron4wma_agent_count.sh`

- Using WMArchive data in HDFS, `/project/monitoring/archive/wmarchive/raw/metric`, calculates daily total number of `wmaid`s per host(WM agent): `count` field
- Adds daily average step count of each host(agent): `avg_steps_count`
- Collects all sites that steps run at in `sites` field
- `wmats_midday` is 12PM of daily aggregation. Aggregation job uses `wmats` for day time window
- Sends data to es-cms1.cern.ch "test" tenant: `test-wmarchive-agent-count-YYYY-MM` index
- WEEKLY cron job with 3 days of buffer for flume jobs' delay that write WMArchive data to HDFS.
