### PR TITLE
Fix gh workflow set-output deprecation and remove init-job

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,25 +2,20 @@
 
 ### 1 - build-docker-spark.yml
 
-This wf builds docker images that use CMSSpark repository. It provides additional functionalities via Git tag **messages**.
+This wf builds `registry.cern.ch/cmsmonitoring/cmsmon-spark` docker image.
+
+> cmsmon-spark image uses `cmsmon-hadoop-base:spark3-latest` as base image. Therefore, that image:tag should be updated regularly (i.e. in each quarter).
 
 ##### How it works:
 
-Provided git tag will be used in the CMSSpark repository checkout. Git tag message will provide more interactive
-management of GitHub actions.
+Provided git tag will be used in the CMSSpark repository's git checkout.
 
-###### There are 2 conventions currently:
+---
 
-1. **Builds all docker images**: `Build docker all.*`
-    - Will build all docker images with given git tag version as docker tag. Put any comment after `Build docker all` string.  
-    - _Example_: `Build docker all`
-    - _Example_: `Build docker all SOME COMMENTS`
+### [Not in use] GH workflow to run multiple builds depending on tag message of same git tag
 
-2. **Builds individual docker images**: `Build docker [(](.+)[)]`
-    - Will build individual docker images which is provided in the git tag message. Put any comment after `Build docker (images)` string
-    - Docker image name(s) should be provided between parenthesis. 
-    - _Examples_:
-        - `Build docker (cmsmon-spark)`
-        - `Build docker (cmsmon-spark) SOME COMMENTS`
+This option is removed because our GH action builds one docker image triggered by one git tag currently.
 
-> Docker images use `cmsmon-hadoop-base:spark3-latest` as base image. Therefore, that image:tag should be updated regularly (i.e. in each quarter).
+Please check this commit if you want to build multiple docker images by defining keywords in git tag message and trigger them with same git tag: https://github.com/dmwm/CMSSpark/blob/5cc37deccb68cb2595ec087f25c0a60cfc9ac610/.github/workflows/build-docker-spark.yml
+
+Also, you can see a proper example in https://github.com/dmwm/CMSMonitoring/blob/585641fbfe010e27f27bf50de144d8f04018e7c3/.github/workflows/build-rucio-dataset-monitoring.yml

--- a/.github/workflows/build-docker-spark.yml
+++ b/.github/workflows/build-docker-spark.yml
@@ -7,59 +7,16 @@ on:
       - 'v*.*.*'
 
 jobs:
-  init-job:
-    runs-on: ubuntu-latest
-    outputs:
-      git_tag: ${{ steps.step1.outputs.git_tag }}
-      action: ${{ steps.step1.outputs.action }}
-      docker_individual_images: ${{ steps.step1.outputs.individual_images }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
-      - id: step1
-        run: |
-          # Define git tag commit message regex rules that users should obey to use functionalities
-          #    "\d" kind regex expressions does not work!
-          REGEX_BUILD_ALL='Build docker all.*'
-          REGEX_BUILD_INDIVIDUALS='Build docker [(](.+)[)].*'
-          
-          # Get git tag and set as "git_tag" variable
-          echo "::set-output name=git_tag::${GITHUB_REF/refs\/tags\//}"
-          
-          # Get tag commit message
-          GIT_TAG_MSG="$(git tag -l --format="%(contents)" $GITHUB_REF_NAME)"
-          echo "Tag message:" $GIT_TAG_MSG
-          
-          # Check that tag commit message obeys regex rules
-          
-          # Check all
-          if [[ $GIT_TAG_MSG =~ $REGEX_BUILD_ALL ]]; then
-              echo "Action: all"
-              echo "::set-output name=action::all"
-              exit 0
-          fi
-          # Check individuals
-          if [[ $GIT_TAG_MSG =~ $REGEX_BUILD_INDIVIDUALS && ! -z "${BASH_REMATCH[1]}" ]]; then
-              echo "Action: individuals, individual_images: ${BASH_REMATCH[1]}"
-              echo "::set-output name=action::individuals"
-              echo "::set-output name=individual_images::${BASH_REMATCH[1]}"
-              exit 0
-          fi
-          # Fail message
-          echo "failure, NO REGEX IS MATCHED WITH THE TAG MESSAGE"
-
   build-cmsmon-spark:
     runs-on: ubuntu-latest
-    needs: [ init-job ]
-    if: |
-      needs.init-job.outputs.action == 'all' || 
-      contains(needs.init-job.outputs.docker_individual_images, 'cmsmon-spark')
     name: Build cmsmon-spark
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
+      - name: Get git tag
+        id: get_tag
+        run: echo "tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
       - name: Get cmsmon-spark Dockerfile
         run: |
           curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/cmsmon-spark/Dockerfile
@@ -76,5 +33,5 @@ jobs:
           file: ./Dockerfile
           push: true
           build-args: |
-            CMSSPARK_TAG=${{ needs.init-job.outputs.git_tag }}
-          tags: registry.cern.ch/cmsmonitoring/cmsmon-spark:${{ needs.init-job.outputs.git_tag }}, registry.cern.ch/cmsmonitoring/cmsmon-spark:latest
+            CMSSPARK_TAG=${{ steps.get_tag.outputs.tag }}
+          tags: registry.cern.ch/cmsmonitoring/cmsmon-spark:${{ steps.get_tag.outputs.tag }}, registry.cern.ch/cmsmonitoring/cmsmon-spark:latest


### PR DESCRIPTION
- In CMSSpark, we build only `cmsmon-spark` now. We don't need `init-job` that helps to run different builds with one tag using keywords in tag message.
- Solves GitHub `set-output` deprecation: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/