### PR TITLE
Fix GitHub workflows

### DIFF
--- a/.github/workflows/build-docker-spark.yml
+++ b/.github/workflows/build-docker-spark.yml
@@ -19,7 +19,8 @@ jobs:
         run: echo "tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
       - name: Get cmsmon-spark Dockerfile
         run: |
-          curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/cmsmon-spark/
+          curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/cmsmon-spark/Dockerfile
+          curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/cmsmon-spark/install.sh
       - name: Login to registry.cern.ch
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/build-docker-spark.yml
+++ b/.github/workflows/build-docker-spark.yml
@@ -19,7 +19,7 @@ jobs:
         run: echo "tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
       - name: Get cmsmon-spark Dockerfile
         run: |
-          curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/cmsmon-spark/Dockerfile
+          curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/cmsmon-spark/
       - name: Login to registry.cern.ch
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/build-docker-spark.yml
+++ b/.github/workflows/build-docker-spark.yml
@@ -20,7 +20,10 @@ jobs:
       - name: Get cmsmon-spark Dockerfile
         run: |
           curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/cmsmon-spark/Dockerfile
+      - name: Get helper script and make it executable
+        run: |
           curl -ksLO https://raw.githubusercontent.com/dmwm/CMSKubernetes/master/docker/cmsmon-spark/install.sh
+          chmod +x install.sh
       - name: Login to registry.cern.ch
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
After the last update of the `cmsmon-spark` Docker (https://github.com/dmwm/CMSKubernetes/pull/1384), the workflow wasn't working as the `install.sh` wasn't included into the workflow.

FYI @mrceyhun @brij01 @leggerf 