### PR TITLE
Update wma_agent_count_to_opensearch.py

### DIFF
--- a/src/python/CMSSpark/wma_agent_count_to_opensearch.py
+++ b/src/python/CMSSpark/wma_agent_count_to_opensearch.py
@@ -61,7 +61,7 @@ def udf_step_extract(row):
     site_name, count = "UNKNOWN", 0
 
     result = {'host': host, 'ts': ts, 'wmaid': wmaid, 'wmats': wmats}
-    if 'steps' in row:
+    if 'steps' in row and row['steps']:
         for step in row['steps']:
             count += 1
             if step['site'] is not None:


### PR DESCRIPTION
This script has been failing with the message `'NoneType' object is not iterable` for quite a long time and this additional check for `NoneType` should fix it.

FYI @leggerf @brij01 