### PR TITLE
Update get_candidate_files function

### DIFF
--- a/src/python/CMSSpark/spark_utils.py
+++ b/src/python/CMSSpark/spark_utils.py
@@ -772,19 +772,12 @@ def get_candidate_files(start_date, end_date, spark, base, day_delta=1):
     ed_date = end_date + timedelta(days=day_delta)
     days = (ed_date - st_date).days
 
-    # pre_candidate_files = [
-    #     "{base}/{day}{{,.tmp}}".format(
-    #         base=base, day=(st_date + timedelta(days=i)).strftime("%Y/%m/%d")
-    #     )
-    #     for i in range(0, days)
-    # ]
-
     sc = spark.sparkContext
     # The candidate files are the folders to the specific dates,
     # but if we are looking at recent days the compaction procedure could
-    # have not run yet so we will considerate also the .tmp folders.
+    # have not run yet, so we will consider also the .tmp folders.
     candidate_files = [
-        f"{base}/{(st_date + timedelta(days=i)).strftime('%Y/%m/%d')}"
+        f"{base}/{(st_date + timedelta(days=i)).strftime('%Y/%m/%d')}{{,.tmp}}"
         for i in range(0, days)
     ]
     fsystem = sc._gateway.jvm.org.apache.hadoop.fs.FileSystem


### PR DESCRIPTION
File compacting job of condor files has been failing and therefore the files in HDFS had `.tmp` suffix. Because of this [hpc_running_cores_and_corehr.py](https://github.com/dmwm/CMSSpark/blob/master/src/python/CMSSpark/hpc_running_cores_and_corehr.py) job was failing because `get_candidate_files` function was searching only for the files without the suffix.

This change fixed the issue for this job, but looking at the git history it seems that previously `get_candidate_files` was changed to NOT include `.tmp` files because it was causing issues (see https://github.com/dmwm/CMSSpark/pull/114). Therefore we still need to check if this fix doesn't break anything in the other cronjobs before merging it.

FYI @leggerf @brij01 