### PR TITLE
Add CHULA to _HPC_SITES_STACK_ORDER list

### DIFF
--- a/src/python/CMSSpark/hpc_running_cores_and_corehr.py
+++ b/src/python/CMSSpark/hpc_running_cores_and_corehr.py
@@ -37,7 +37,7 @@ _BASE_HDFS_CONDOR = '/project/monitoring/archive/condor/raw/metric'
 
 # Bottom to top bar stack order which set same colors for same site always
 _HPC_SITES_STACK_ORDER = ['ANL', 'ANVIL', 'BSC', 'CINECA', 'HOREKA', 'NERSC', 'OSG', 'PSC', 'RWTH', 'SDSC', 'TACC',
-                          'VEGA']
+        'VEGA', 'CHULA']
 
 # For new sites, please check list sizes
 DISCRETE_COLOR_MAP = {site: px.colors.qualitative.Light24[i] for i, site in enumerate(_HPC_SITES_STACK_ORDER)}


### PR DESCRIPTION
Added new CNAF-CHULA site to the HPC monitoring system, as requested by @pdinie831 in [CMSMONIT-652](https://its.cern.ch/jira/browse/CMSMONIT-652).

This PR is a follow-up to #171 and #172