### PR TITLE
Refactor HS06 CPU Time plot cronjob

### DIFF
--- a/docker/hs06-cputime-plot/Dockerfile
+++ b/docker/hs06-cputime-plot/Dockerfile
@@ -1,0 +1,9 @@
+# cmsmon-hs06-cputime-plot
+FROM registry.cern.ch/cmsmonitoring/cmsmon-spark:test
+LABEL maintainer="Carlos Borrajo Gomez carlos.borrajo.gomez@cern.ch"
+
+ENV WDIR=/opt/spark-apps/hs06-cputime-plot
+WORKDIR $WDIR
+
+COPY src/ $WDIR/
+

--- a/docker/hs06-cputime-plot/README.md
+++ b/docker/hs06-cputime-plot/README.md
@@ -1,0 +1,5 @@
+# HS06 CPU Time Plot generation cron job
+
+Generates datasets and plots for HS06 core hours either by week of year or by month for a given calendar year.
+
+The cronjob in Kubernetes runs on the 19th of each month at 22:00 and outputs the results to the [HS06 CPU Time section](https://cmsdatapop.web.cern.ch/cmsdatapop/hs06cputime/) of the CMS Data Popularity website. The data itself is used in panels in the  [C-RSG Plots Dashboard](https://monit-grafana.cern.ch/goto/3H4qew9Hg?orgId=11) ([1](https://monit-grafana.cern.ch/goto/SW_9eQrNg?orgId=11) and [2](https://monit-grafana.cern.ch/goto/COTgR_9HR?orgId=11)).

--- a/docker/hs06-cputime-plot/README.md
+++ b/docker/hs06-cputime-plot/README.md
@@ -2,4 +2,4 @@
 
 Generates datasets and plots for HS06 core hours either by week of year or by month for a given calendar year.
 
-The cronjob in Kubernetes runs on the 19th of each month at 22:00 and outputs the results to the [HS06 CPU Time section](https://cmsdatapop.web.cern.ch/cmsdatapop/hs06cputime/) of the CMS Data Popularity website. The data itself is used in panels in the  [C-RSG Plots Dashboard](https://monit-grafana.cern.ch/goto/3H4qew9Hg?orgId=11) ([1](https://monit-grafana.cern.ch/goto/SW_9eQrNg?orgId=11) and [2](https://monit-grafana.cern.ch/goto/COTgR_9HR?orgId=11)).
+The cronjob in Kubernetes runs on the 19th of each month at 22:00 and outputs the results to the [HS06 CPU Time section](https://cmsdatapop.web.cern.ch/cmsdatapop/hs06cputime/) of the CMS Data Popularity website. The data itself is used in panels in the  [C-RSG Plots Dashboard](https://monit-grafana.cern.ch/goto/3H4qew9Hg?orgId=11) ([Fig 2](https://monit-grafana.cern.ch/goto/SW_9eQrNg?orgId=11) and [Fig 4](https://monit-grafana.cern.ch/goto/COTgR_9HR?orgId=11)).

--- a/docker/hs06-cputime-plot/src/condor_hs06coreHrPlot.py
+++ b/docker/hs06-cputime-plot/src/condor_hs06coreHrPlot.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+File        : condor_hs06coreHrPlot.py
+Author      : Christian Ariza <christian.ariza AT gmail [DOT] com>
+Description : Generate datasets and plots for HS06 core hours ...
+              ... either by week of year or by month for a given calendar year.
+"""
+
+# system modules
+import os
+
+import click
+import matplotlib.pyplot as plt
+import seaborn as sns
+from pyspark.sql.functions import from_unixtime, col, year, month, weekofyear
+from pyspark.sql.types import StructType, LongType, StringType, StructField, DoubleType
+
+# CMSSpark modules
+from helpers.spark_utils import get_candidate_files, get_spark_session
+
+# global variables
+_BASE_HDFS_CONDOR = "/project/monitoring/archive/condor/raw/metric"
+_VALID_DATE_FORMATS = ["%Y/%m/%d", "%Y-%m-%d", "%Y%m%d"]
+_VALID_BY = ("weekofyear", "month")
+
+
+def _get_hs06_condor_schema():
+    """
+    Define the subset of the condor schema that we will use
+    in this application.
+    """
+    schema = StructType(
+        [
+            StructField(
+                "data",
+                StructType(
+                    [
+                        StructField("GlobalJobId", StringType(), nullable=False),
+                        StructField("RecordTime", LongType(), nullable=False),
+                        StructField("HS06CpuTimeHr", DoubleType(), nullable=True),
+                        StructField("Status", StringType(), nullable=True),
+                        StructField("Site", StringType(), nullable=True),
+                        StructField("Type", StringType(), nullable=True),
+                    ]
+                ),
+            )
+        ]
+    )
+    return schema
+
+
+def get_hs06CpuTImeHr(start_date, end_date, by="month", base=_BASE_HDFS_CONDOR, include_re="^T2_.*$",
+                      exclude_re=".*_CERN.*"):
+    """Query the hdfs data and returns a pandas dataframe
+
+    with: year, [weekofyear/month], sum(HS06CpuTimeHr)
+    args:
+        - start_date datetime Start of the query period (RecordTime)
+        - end_date datetime End of the query period
+    """
+    if by not in _VALID_BY:
+        raise ValueError(f"by must be one of {_VALID_BY}")
+    start = int(start_date.timestamp() * 1000)
+    end = int(end_date.timestamp() * 1000)
+    spark = get_spark_session(app_name="cms-hs06corehrs_plot")
+
+    dfs_raw = (
+        spark.read.option("basePath", base)
+        .json(
+            get_candidate_files(start_date, end_date, spark, base=base, day_delta=1), schema=_get_hs06_condor_schema()
+        )
+        .select("data.*")
+        .filter(
+            f"""Status='Completed'
+                  AND Site rlike '{include_re}' 
+                  AND NOT Site rlike '{exclude_re}'
+                  AND RecordTime>={start}
+                  AND RecordTime<{end}
+                  """
+        )
+        .withColumn("RecordDate", from_unixtime(col("RecordTime") / 1000))
+        .withColumn("weekofyear", weekofyear("RecordDate"))
+        .withColumn("month", month("RecordDate"))
+        .withColumn("year", year("RecordDate"))
+    )
+    grouped_sdf = (
+        dfs_raw.drop_duplicates(["GlobalJobId"])
+        .groupby(["year", by])
+        .agg({"HS06CpuTimeHr": "sum"})
+    )
+    return grouped_sdf.toPandas()
+
+
+def generate_plot(pdf, by, output_folder, filename):
+    """
+    Generates and save in the output_folder a bar plot
+    for the given dataset. The dataset must include year,
+    either a month or a weekofyear, and sum(HS06 kdays).
+    If the year is the same for all the records, only the month/weekofyear
+    will be used in the labels, otherwise it will show year-month or
+    year-weekofyear.
+    """
+    group_field = by if pdf.year.nunique() == 1 else "period"
+    if group_field == "period":
+        pdf["period"] = pdf.year.astype(str) + "-" + pdf[by].astype(str).str.zfill(2)
+    sorted_pd = pdf.sort_values(group_field)
+    _dims = (18, 8.5)
+    fig, ax = plt.subplots(figsize=_dims)
+    plot = sns.barplot(data=sorted_pd, x=group_field, y="HS06 kdays", color="tab:blue")
+    fig.text(0.1, -0.08, filename, fontsize=10)
+    fig.savefig(os.path.join(output_folder, f"{filename}.png"), bbox_inches="tight")
+
+
+@click.command()
+@click.option("--start_date", type=click.DateTime(_VALID_DATE_FORMATS))
+@click.option("--end_date", type=click.DateTime(_VALID_DATE_FORMATS))
+@click.option("--by", default="month", type=click.Choice(_VALID_BY), show_default=True,
+              help="Either weekofyear or month")
+@click.option("--include_re", default="^T2_.*$", show_default=True,
+              help="Regular expression to select the sites to include in the plot")
+@click.option("--exclude_re", default=".*_CERN.*", show_default=True,
+              help="Regular expression to select the sites to exclude of the plot")
+@click.option("--generate_plots", default=False, is_flag=True,
+              help="Additional to the csv, generate the plot(s)")
+@click.option("--output_folder", default="./output", help="local output directory")
+def main(start_date, end_date, output_folder, by="month", generate_plots=False, include_re=".*", exclude_re=".*"):
+    """This script will generate a dataset with the number of unique users of CRAB
+
+        either by month or by weekofyear.
+    """
+    cp_pdf = get_hs06CpuTImeHr(start_date, end_date, by, include_re=include_re, exclude_re=exclude_re)
+
+    cp_pdf["HS06 kdays"] = cp_pdf["sum(HS06CpuTimeHr)"] / 24000.0
+    os.makedirs(output_folder, exist_ok=True)
+    filename = f"HS06CpuTimeHr_{by}_{start_date.strftime('%Y%m%d')}-{end_date.strftime('%Y%m%d')}"
+    cp_pdf.to_csv(os.path.join(output_folder, f"{filename}.csv"))
+    if generate_plots:
+        generate_plot(cp_pdf, by, output_folder, filename)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/hs06-cputime-plot/src/cron4hs06_cputime_plot.sh
+++ b/docker/hs06-cputime-plot/src/cron4hs06_cputime_plot.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# shellcheck disable=SC2068
+set -e
+##H cron4hs06_cputime_plot.sh
+##H    Creates HS06 CPU time plots
+##H    This script will generate two plots and two datasets, one with monthly values and other with weekly values.
+##H    Spark job will cover a 1 year period, ending in the first day of the current month (without including it)
+##H
+##H Example: cron4hs06_cputime_plot.sh --keytab ./keytab --output <DIR> --p1 32000 --p2 32001 --host $MY_NODE_NAME --wdir $WDIR
+##H Arguments:
+##H   - keytab             : Kerberos auth file: secrets/keytab
+##H   - output             : Output directory. If not given, $HOME/output will be used. I.e /eos/user/c/cmsmonit/www/hs06cputime
+##H   - p1, p2, host, wdir : [ALL FOR K8S] p1 and p2 spark required ports(driver and blockManager), host is k8s node dns alias, wdir is working directory
+##H   - test               : Flag that will process 2 months of data instead of 1 year.
+##H How to test: Just provide test directory as output directory.
+##H
+TZ=UTC
+START_TIME=$(date +%s)
+myname=$(basename "$0")
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+. /data/utils/common_utils.sh
+
+if [ "$1" == "" ] || [ "$1" == "-h" ] || [ "$1" == "--help" ] || [ "$1" == "-help" ]; then
+    util_usage_help
+    exit 0
+fi
+util_cron_send_start "$myname" "1M"
+
+unset -v KEYTAB_SECRET OUTPUT_DIR PORT1 PORT2 K8SHOST WDIR IS_TEST
+# ------------------------------------------------------------------------------------------------------------- PREPARE
+util_input_args_parser $@
+
+util4logi "Parameters: KEYTAB_SECRET:${KEYTAB_SECRET} OUTPUT_DIR:${OUTPUT_DIR} PORT1:${PORT1} PORT2:${PORT2} K8SHOST:${K8SHOST} WDIR:${WDIR} IS_TEST:${IS_TEST}"
+util_check_vars PORT1 PORT2 K8SHOST
+util_setup_spark_k8s
+
+KERBEROS_USER=$(util_kerberos_auth_with_keytab "$KEYTAB_SECRET")
+util4logi "authenticated with Kerberos user: ${KERBEROS_USER}"
+util_check_and_create_dir "$OUTPUT_DIR"
+
+# ----------------------------------------------------------------------------------------------------------------- RUN
+util4logi "${myname} Spark Job is starting..."
+
+spark_submit_args=(
+    --master yarn --conf spark.ui.showConsoleProgress=false --conf spark.sql.session.timeZone=UTC
+    --conf spark.shuffle.useOldFetchProtocol=true
+    --driver-memory=4g --executor-memory=8g --executor-cores=4 --num-executors=30
+    --conf "spark.driver.bindAddress=0.0.0.0" --conf "spark.driver.host=${K8SHOST}"
+    --conf "spark.driver.port=${PORT1}" --conf "spark.driver.blockManager.port=${PORT2}"
+    --packages org.apache.spark:spark-avro_2.12:3.4.0
+)
+
+# run spark function
+function run_spark() {
+    spark-submit "${spark_submit_args[@]}" "$script_dir/condor_hs06coreHrPlot.py" "$@"
+}
+
+END_DATE="$(date +%Y-%m-01)"
+START_DATE="$(date -d "$END_DATE -1 year" +%Y-%m-01)"
+# If test, process only 1 months
+if [[ "$IS_TEST" == 1 ]]; then
+    START_DATE="$(date -d "$END_DATE -1 month" +%Y-%m-01)"
+fi
+
+util4logi "Plots from $START_DATE to $END_DATE"
+
+# T2 sites excluding cern.
+run_spark --generate_plots --by "month" --output_folder "$OUTPUT_DIR/T2" --start_date "$START_DATE" --end_date "$END_DATE"
+run_spark --generate_plots --by "weekofyear" --output_folder "$OUTPUT_DIR/T2" --start_date "$START_DATE" --end_date "$END_DATE"
+
+ln -s -f "$OUTPUT_DIR/T2/HS06CpuTimeHr_month_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).csv" "$OUTPUT_DIR/T2/HS06CpuTimeHr_month_latest.csv"
+ln -s -f "$OUTPUT_DIR/T2/HS06CpuTimeHr_month_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).png" "$OUTPUT_DIR/T2/HS06CpuTimeHr_month_latest.png"
+ln -s -f "$OUTPUT_DIR/T2/HS06CpuTimeHr_weekofyear_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).csv" "$OUTPUT_DIR/T2/HS06CpuTimeHr_weekofyear_latest.csv"
+ln -s -f "$OUTPUT_DIR/T2/HS06CpuTimeHr_weekofyear_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).png" "$OUTPUT_DIR/T2/HS06CpuTimeHr_weekofyear_latest.png"
+
+# T1 sites
+run_spark --generate_plots --by "month" --include_re "T1_.*" --exclude_re "^$" --output_folder "$OUTPUT_DIR/T1" --start_date "$START_DATE" --end_date "$END_DATE"
+run_spark --generate_plots --by "weekofyear" --include_re "T1_.*" --exclude_re "^$" --output_folder "$OUTPUT_DIR/T1" --start_date "$START_DATE" --end_date "$END_DATE"
+
+ln -s -f "$OUTPUT_DIR/T1/HS06CpuTimeHr_month_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).csv" "$OUTPUT_DIR/T1/HS06CpuTimeHr_month_latest.csv"
+ln -s -f "$OUTPUT_DIR/T1/HS06CpuTimeHr_month_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).png" "$OUTPUT_DIR/T1/HS06CpuTimeHr_month_latest.png"
+ln -s -f "$OUTPUT_DIR/T1/HS06CpuTimeHr_weekofyear_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).csv" "$OUTPUT_DIR/T1/HS06CpuTimeHr_weekofyear_latest.csv"
+ln -s -f "$OUTPUT_DIR/T1/HS06CpuTimeHr_weekofyear_$(date -d "$START_DATE" +%Y%m%d)-$(date -d "$END_DATE" +%Y%m%d).png" "$OUTPUT_DIR/T1/HS06CpuTimeHr_weekofyear_latest.png"
+
+duration=$(($(date +%s) - START_TIME))
+util_cron_send_end "$myname" "1M" 0
+util4logi "all finished, time spent: $(util_secs_to_human $duration)"


### PR DESCRIPTION
As part of [CMSMONIT-681](https://its.cern.ch/jira/browse/CMSMONIT-681) and [CMSMONIT-667](https://its.cern.ch/jira/browse/CMSMONIT-667), we are refactoring the Docker image for the service generating the HS06 CPU Time plots and we are moving its codebase to the CMSSpark repository.