### PR TITLE
Fix broken path in gen crsg plots

### DIFF
--- a/docker/cmsmon-spark/utils/common_utils.sh
+++ b/docker/cmsmon-spark/utils/common_utils.sh
@@ -177,15 +177,22 @@ function util_set_java_home() {
 #    fail   : exits with exit-code 1
 #######################################
 function util_kerberos_auth_with_keytab() {
-    local principle
-    principle=$(klist -k "$1" | tail -1 | awk '{print $2}')
+    local principal krb5ccname
+    principal=$(klist -k "$1" | tail -1 | awk '{print $2}')
     # run kinit and check if it fails or not
-    if ! kinit "$principle" -k -t "$1" >/dev/null; then
+    if ! kinit "$principal" -k -t "$1" >/dev/null; then
         util4loge "Exiting. Kerberos authentication failed with keytab:$1"
         exit 1
     fi
-    # remove "@" part from the principle name
-    echo "$principle" | grep -o '^[^@]*'
+    # eosxd-csi no longer sets KRB5CCNAME automatically, so set it explicitly.
+    krb5ccname=$(klist | grep "Ticket cache:" | sed -E 's/.*FILE:(\/\/)?//')
+    if [ -z "$krb5ccname" ]; then
+        util4loge "Exiting. Failed to detect Kerberos ticket cache path from klist output."
+        exit 1
+    fi
+    export KRB5CCNAME="$krb5ccname"
+    # remove "@" part from the principal name
+    echo "$principal" | grep -o '^[^@]*'
 }
 
 #######################################

--- a/docker/gen-crsg-plots/Dockerfile
+++ b/docker/gen-crsg-plots/Dockerfile
@@ -1,5 +1,5 @@
 # cmsmon-gen-crsg-plots
-FROM registry.cern.ch/cmsmonitoring/cmsmon-spark:test
+FROM registry.cern.ch/cmsmonitoring/cmsmon-spark:v1.0.0
 LABEL maintainer="Carlos Borrajo Gomez carlos.borrajo.gomez@cern.ch"
 
 ENV WDIR=/opt/spark-apps/gen-crsg-plots

--- a/docker/gen-crsg-plots/src/dbs_event_count_plot.py
+++ b/docker/gen-crsg-plots/src/dbs_event_count_plot.py
@@ -32,12 +32,38 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import seaborn as sns
 
-from helpers import spark_utils
+import helpers.schemas as schemas
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 _VALID_DATE_FORMATS = ["%Y/%m"]
 _VALID_TYPES = ["pdf", "png", "jpg", "svg"]
+CMS_DBS_HDFS_FOLDER = "/project/awg/cms/dbs/PROD_GLOBAL"
+
+
+def load_dbs_tables(spark, fdate=None):
+    """Load DBS tables from the latest daily PROD_GLOBAL snapshot."""
+    if fdate is None:
+        fdate = datetime.today().strftime("%Y-%m-%d")
+    hdfs_paths = {
+        "DATASETS": f"{CMS_DBS_HDFS_FOLDER}/{fdate}/DATASETS/*.gz",
+        "BLOCKS": f"{CMS_DBS_HDFS_FOLDER}/{fdate}/BLOCKS/*.gz",
+        "FILES": f"{CMS_DBS_HDFS_FOLDER}/{fdate}/FILES/*.gz",
+        "DATA_TIERS": f"{CMS_DBS_HDFS_FOLDER}/{fdate}/DATA_TIERS/*.gz",
+    }
+    logger.info("Loading DBS tables from %s", fdate)
+    csvreader = (
+        spark.read.format("csv").option("nullValue", "null").option("mode", "FAILFAST")
+    )
+    ddf = csvreader.schema(schemas.schema_datasets()).load(hdfs_paths["DATASETS"])
+    ddf.registerTempTable("ddf")
+    bdf = csvreader.schema(schemas.schema_blocks()).load(hdfs_paths["BLOCKS"])
+    bdf.registerTempTable("bdf")
+    fdf = csvreader.schema(schemas.schema_files()).load(hdfs_paths["FILES"])
+    fdf.registerTempTable("fdf")
+    dtf = csvreader.schema(schemas.schema_data_tiers()).load(hdfs_paths["DATA_TIERS"])
+    dtf.registerTempTable("dtf")
+    return {"ddf": ddf, "bdf": bdf, "fdf": fdf, "dtf": dtf}
 
 
 def plot_tiers_month(data, colors_file=None, attributes=None):
@@ -139,7 +165,7 @@ def get_events_by_tier_month(spark, start_date, end_date,
         if remove_raw
         else "^$"
     )
-    tables = spark_utils.dbs_tables(spark, tables=["ddf", "bdf", "fdf", "dtf"])
+    tables = load_dbs_tables(spark)
     if verbose:
         logger.info("remove %s", remove_rlike)
         logger.info("skims %s", skims_rlike)


### PR DESCRIPTION
This PR fixes the gen-crsg-plots cronjob after it was broken in commit [8e26da7](https://github.com/dmwm/CMSMonitoring/commit/8e26da7e186b206ac278399b72aaa47d6026b143). This commit deleted a step in the sqoop job that duplicated the data between the current path where it writes the data and the original path, rendering this cronjob obsolete by relying on the old path.

This fixes the pathing and refactors the logic to account for the new structure.