### PR TITLE
Fix krb5ccname to use with new k8s templates

### DIFF
--- a/docker/cmsmon-spark/utils/common_utils.sh
+++ b/docker/cmsmon-spark/utils/common_utils.sh
@@ -177,15 +177,22 @@ function util_set_java_home() {
 #    fail   : exits with exit-code 1
 #######################################
 function util_kerberos_auth_with_keytab() {
-    local principle
-    principle=$(klist -k "$1" | tail -1 | awk '{print $2}')
+    local principal krb5ccname
+    principal=$(klist -k "$1" | tail -1 | awk '{print $2}')
     # run kinit and check if it fails or not
-    if ! kinit "$principle" -k -t "$1" >/dev/null; then
+    if ! kinit "$principal" -k -t "$1" >/dev/null; then
         util4loge "Exiting. Kerberos authentication failed with keytab:$1"
         exit 1
     fi
-    # remove "@" part from the principle name
-    echo "$principle" | grep -o '^[^@]*'
+    # eosxd-csi no longer sets KRB5CCNAME automatically, so set it explicitly.
+    krb5ccname=$(klist | grep "Ticket cache:" | sed -E 's/.*FILE:(\/\/)?//')
+    if [ -z "$krb5ccname" ]; then
+        util4loge "Exiting. Failed to detect Kerberos ticket cache path from klist output."
+        exit 1
+    fi
+    export KRB5CCNAME="$krb5ccname"
+    # remove "@" part from the principal name
+    echo "$principal" | grep -o '^[^@]*'
 }
 
 #######################################


### PR DESCRIPTION
Add a fix to the kerberos authentication in the spark images to solve an issue with the new k8s templates